### PR TITLE
Move GitHub release creation to separate job

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 566d4ed
+_commit: 0.1.0
 _src_path: .
 copyright_holder: Stephen Kent
 copyright_holder_email: smkent@smkent.net

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: write
     steps:
       - name: 🔽 Download artifact
         uses: actions/download-artifact@v4
@@ -52,6 +51,19 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           attestations: true
+
+  release:
+    name: Create GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 🔽 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: 🏷️ Create GitHub release
         run: gh release create ${{ github.ref_name }} dist/* --generate-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Move GitHub release creation to a separate job for build artifact availability
+
 ## [0.1.0] - 2026-03-31
 
 ### Added

--- a/template/{% if project_visibility == 'public' %}.github{% endif %}/workflows/{% if enable_pypi %}release.yaml{% endif %}.jinja
+++ b/template/{% if project_visibility == 'public' %}.github{% endif %}/workflows/{% if enable_pypi %}release.yaml{% endif %}.jinja
@@ -41,7 +41,6 @@ jobs:
     permissions:
       id-token: write
       attestations: write
-      contents: write
     steps:
       - name: 🔽 Download artifact
         uses: actions/download-artifact@v4
@@ -54,8 +53,21 @@ jobs:
         with:
           attestations: true
 
+  release:
+    name: Create GitHub release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 🔽 Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
       - name: 🏷️ Create GitHub release
-        run: gh release create ${{ '{{' }} github.ref_name {{ '}}' }} dist/* --generate-notes
+        run: gh release create {% raw %}${{ github.ref_name }}{% endraw %} dist/* --generate-notes
         env:
-          GH_TOKEN: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
+          GH_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
 {#- vim: set ft=yaml: #}


### PR DESCRIPTION
GitHub release creation now depends on pypi publishing success