### PR TITLE
Refresh license templates from original sources

### DIFF
--- a/includes/licenses/AGPL-3.0
+++ b/includes/licenses/AGPL-3.0
@@ -1,35 +1,35 @@
-GNU AFFERO GENERAL PUBLIC LICENSE
-   Version 3, 19 November 2007
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-        Preamble
+                            Preamble
 
-The GNU Affero General Public License is a free, copyleft license for
+  The GNU Affero General Public License is a free, copyleft license for
 software and other kinds of works, specifically designed to ensure
 cooperation with the community in the case of network server software.
 
-The licenses for most software and other practical works are designed
+  The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
 our General Public Licenses are intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
 software for all its users.
 
-When we speak of free software, we are referring to freedom, not
+  When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-Developers that use our General Public Licenses protect your rights
+  Developers that use our General Public Licenses protect your rights
 with two steps: (1) assert copyright on the software, and (2) offer
 you this License which gives you legal permission to copy, distribute
 and/or modify the software.
 
-A secondary benefit of defending all users' freedom is that
+  A secondary benefit of defending all users' freedom is that
 improvements made in alternate versions of the program, if they
 receive widespread use, become available for other developers to
 incorporate.  Many developers of free software are heartened and
@@ -39,7 +39,7 @@ The GNU General Public License permits making a modified version and
 letting the public access it on a server without ever releasing its
 source code to the public.
 
-The GNU Affero General Public License is designed specifically to
+  The GNU Affero General Public License is designed specifically to
 ensure that, in such cases, the modified source code becomes available
 to the community.  It requires the operator of a network server to
 provide the source code of the modified version running there to the
@@ -47,48 +47,48 @@ users of that server.  Therefore, public use of a modified version, on
 a publicly accessible server, gives the public access to the source
 code of the modified version.
 
-An older license, called the Affero General Public License and
+  An older license, called the Affero General Public License and
 published by Affero, was designed to accomplish similar goals.  This is
 a different license, not a version of the Affero GPL, but Affero has
 released a new version of the Affero GPL which permits relicensing under
 this license.
 
-The precise terms and conditions for copying, distribution and
+  The precise terms and conditions for copying, distribution and
 modification follow.
 
-   TERMS AND CONDITIONS
+                       TERMS AND CONDITIONS
 
-0. Definitions.
+  0. Definitions.
 
-"This License" refers to version 3 of the GNU Affero General Public License.
+  "This License" refers to version 3 of the GNU Affero General Public License.
 
-"Copyright" also means copyright-like laws that apply to other kinds of
+  "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
 
-"The Program" refers to any copyrightable work licensed under this
+  "The Program" refers to any copyrightable work licensed under this
 License.  Each licensee is addressed as "you".  "Licensees" and
 "recipients" may be individuals or organizations.
 
-To "modify" a work means to copy from or adapt all or part of the work
+  To "modify" a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
 exact copy.  The resulting work is called a "modified version" of the
 earlier work or a work "based on" the earlier work.
 
-A "covered work" means either the unmodified Program or a work based
+  A "covered work" means either the unmodified Program or a work based
 on the Program.
 
-To "propagate" a work means to do anything with it that, without
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
 public, and in some countries other activities as well.
 
-To "convey" a work means any kind of propagation that enables other
+  To "convey" a work means any kind of propagation that enables other
 parties to make or receive copies.  Mere interaction with a user through
 a computer network, with no transfer of a copy, is not conveying.
 
-An interactive user interface displays "Appropriate Legal Notices"
+  An interactive user interface displays "Appropriate Legal Notices"
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
 tells the user that there is no warranty for the work (except to the
@@ -97,18 +97,18 @@ work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
 
-1. Source Code.
+  1. Source Code.
 
-The "source code" for a work means the preferred form of the work
+  The "source code" for a work means the preferred form of the work
 for making modifications to it.  "Object code" means any non-source
 form of a work.
 
-A "Standard Interface" means an interface that either is an official
+  A "Standard Interface" means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
 is widely used among developers working in that language.
 
-The "System Libraries" of an executable work include anything, other
+  The "System Libraries" of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
 Component, and (b) serves only to enable use of the work with that
@@ -119,7 +119,7 @@ implementation is available to the public in source code form.  A
 (if any) on which the executable work runs, or a compiler used to
 produce the work, or an object code interpreter used to run it.
 
-The "Corresponding Source" for a work in object code form means all
+  The "Corresponding Source" for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
 control those activities.  However, it does not include the work's
@@ -132,16 +132,16 @@ linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
 subprograms and other parts of the work.
 
-The Corresponding Source need not include anything that users
+  The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
 Source.
 
-The Corresponding Source for a work in source code form is that
+  The Corresponding Source for a work in source code form is that
 same work.
 
-2. Basic Permissions.
+  2. Basic Permissions.
 
-All rights granted under this License are granted for the term of
+  All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
 conditions are met.  This License explicitly affirms your unlimited
 permission to run the unmodified Program.  The output from running a
@@ -149,7 +149,7 @@ covered work is covered by this License only if the output, given its
 content, constitutes a covered work.  This License acknowledges your
 rights of fair use or other equivalent, as provided by copyright law.
 
-You may make, run and propagate covered works that you do not
+  You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
 in force.  You may convey covered works to others for the sole purpose
 of having them make modifications exclusively for you, or provide you
@@ -160,19 +160,19 @@ for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
 your copyrighted material outside their relationship with you.
 
-Conveying under any other circumstances is permitted solely under
+  Conveying under any other circumstances is permitted solely under
 the conditions stated below.  Sublicensing is not allowed; section 10
 makes it unnecessary.
 
-3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-No covered work shall be deemed part of an effective technological
+  No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
 measures.
 
-When you convey a covered work, you waive any legal power to forbid
+  When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
 the covered work, and you disclaim any intention to limit operation or
@@ -180,9 +180,9 @@ modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
 technological measures.
 
-4. Conveying Verbatim Copies.
+  4. Conveying Verbatim Copies.
 
-You may convey verbatim copies of the Program's source code as you
+  You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
@@ -190,37 +190,37 @@ non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
 recipients a copy of this License along with the Program.
 
-You may charge any price or no price for each copy that you convey,
+  You may charge any price or no price for each copy that you convey,
 and you may offer support or warranty protection for a fee.
 
-5. Conveying Modified Source Versions.
+  5. Conveying Modified Source Versions.
 
-You may convey a work based on the Program, or the modifications to
+  You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
 terms of section 4, provided that you also meet all of these conditions:
 
-a) The work must carry prominent notices stating that you modified
-it, and giving a relevant date.
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-b) The work must carry prominent notices stating that it is
-released under this License and any conditions added under section
-7.  This requirement modifies the requirement in section 4 to
-"keep intact all notices".
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-c) You must license the entire work, as a whole, under this
-License to anyone who comes into possession of a copy.  This
-License will therefore apply, along with any applicable section 7
-additional terms, to the whole of the work, and all its parts,
-regardless of how they are packaged.  This License gives no
-permission to license the work in any other way, but it does not
-invalidate such permission if you have separately received it.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
-d) If the work has interactive user interfaces, each must display
-Appropriate Legal Notices; however, if the Program has interactive
-interfaces that do not display Appropriate Legal Notices, your
-work need not make them do so.
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-A compilation of a covered work with other separate and independent
+  A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
 in or on a volume of a storage or distribution medium, is called an
@@ -230,59 +230,59 @@ beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
 parts of the aggregate.
 
-6. Conveying Non-Source Forms.
+  6. Conveying Non-Source Forms.
 
-You may convey a covered work in object code form under the terms
+  You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
 in one of these ways:
 
-a) Convey the object code in, or embodied in, a physical product
-(including a physical distribution medium), accompanied by the
-Corresponding Source fixed on a durable physical medium
-customarily used for software interchange.
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
-b) Convey the object code in, or embodied in, a physical product
-(including a physical distribution medium), accompanied by a
-written offer, valid for at least three years and valid for as
-long as you offer spare parts or customer support for that product
-model, to give anyone who possesses the object code either (1) a
-copy of the Corresponding Source for all the software in the
-product that is covered by this License, on a durable physical
-medium customarily used for software interchange, for a price no
-more than your reasonable cost of physically performing this
-conveying of source, or (2) access to copy the
-Corresponding Source from a network server at no charge.
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-c) Convey individual copies of the object code with a copy of the
-written offer to provide the Corresponding Source.  This
-alternative is allowed only occasionally and noncommercially, and
-only if you received the object code with such an offer, in accord
-with subsection 6b.
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-d) Convey the object code by offering access from a designated
-place (gratis or for a charge), and offer equivalent access to the
-Corresponding Source in the same way through the same place at no
-further charge.  You need not require recipients to copy the
-Corresponding Source along with the object code.  If the place to
-copy the object code is a network server, the Corresponding Source
-may be on a different server (operated by you or a third party)
-that supports equivalent copying facilities, provided you maintain
-clear directions next to the object code saying where to find the
-Corresponding Source.  Regardless of what server hosts the
-Corresponding Source, you remain obligated to ensure that it is
-available for as long as needed to satisfy these requirements.
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
 
-e) Convey the object code using peer-to-peer transmission, provided
-you inform other peers where the object code and Corresponding
-Source of the work are being offered to the general public at no
-charge under subsection 6d.
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
 
-A separable portion of the object code, whose source code is excluded
+  A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
 included in conveying the object code work.
 
-A "User Product" is either (1) a "consumer product", which means any
+  A "User Product" is either (1) a "consumer product", which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
 into a dwelling.  In determining whether a product is a consumer product,
@@ -295,7 +295,7 @@ is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
 the only significant mode of use of the product.
 
-"Installation Information" for a User Product means any methods,
+  "Installation Information" for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
 a modified version of its Corresponding Source.  The information must
@@ -303,7 +303,7 @@ suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
 modification has been made.
 
-If you convey an object code work under this section in, or with, or
+  If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
@@ -314,7 +314,7 @@ if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
 been installed in ROM).
 
-The requirement to provide Installation Information does not include a
+  The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
 the User Product in which it has been modified or installed.  Access to a
@@ -322,15 +322,15 @@ network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
 protocols for communication across the network.
 
-Corresponding Source conveyed, and Installation Information provided,
+  Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
 unpacking, reading or copying.
 
-7. Additional Terms.
+  7. Additional Terms.
 
-"Additional permissions" are terms that supplement the terms of this
+  "Additional permissions" are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
 be treated as though they were included in this License, to the extent
@@ -339,41 +339,41 @@ apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
 this License without regard to the additional permissions.
 
-When you convey a copy of a covered work, you may at your option
+  When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
 it.  (Additional permissions may be written to require their own
 removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
 for which you have or can give appropriate copyright permission.
 
-Notwithstanding any other provision of this License, for material you
+  Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
 that material) supplement the terms of this License with terms:
 
-a) Disclaiming warranty or limiting liability differently from the
-terms of sections 15 and 16 of this License; or
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
 
-b) Requiring preservation of specified reasonable legal notices or
-author attributions in that material or in the Appropriate Legal
-Notices displayed by works containing it; or
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
 
-c) Prohibiting misrepresentation of the origin of that material, or
-requiring that modified versions of such material be marked in
-reasonable ways as different from the original version; or
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
 
-d) Limiting the use for publicity purposes of names of licensors or
-authors of the material; or
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
 
-e) Declining to grant rights under trademark law for use of some
-trade names, trademarks, or service marks; or
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
 
-f) Requiring indemnification of licensors and authors of that
-material by anyone who conveys the material (or modified versions of
-it) with contractual assumptions of liability to the recipient, for
-any liability that these contractual assumptions directly impose on
-those licensors and authors.
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
 
-All other non-permissive additional terms are considered "further
+  All other non-permissive additional terms are considered "further
 restrictions" within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
 governed by this License along with a term that is a further
@@ -383,46 +383,46 @@ License, you may add to a covered work material governed by the terms
 of that license document, provided that the further restriction does
 not survive such relicensing or conveying.
 
-If you add terms to a covered work in accord with this section, you
+  If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
 where to find the applicable terms.
 
-Additional terms, permissive or non-permissive, may be stated in the
+  Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
 the above requirements apply either way.
 
-8. Termination.
+  8. Termination.
 
-You may not propagate or modify a covered work except as expressly
+  You may not propagate or modify a covered work except as expressly
 provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
 paragraph of section 11).
 
-However, if you cease all violation of this License, then your
+  However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
 prior to 60 days after the cessation.
 
-Moreover, your license from a particular copyright holder is
+  Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
 your receipt of the notice.
 
-Termination of your rights under this section does not terminate the
+  Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
 material under section 10.
 
-9. Acceptance Not Required for Having Copies.
+  9. Acceptance Not Required for Having Copies.
 
-You are not required to accept this License in order to receive or
+  You are not required to accept this License in order to receive or
 run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
 to receive a copy likewise does not require acceptance.  However,
@@ -431,14 +431,14 @@ modify any covered work.  These actions infringe copyright if you do
 not accept this License.  Therefore, by modifying or propagating a
 covered work, you indicate your acceptance of this License to do so.
 
-10. Automatic Licensing of Downstream Recipients.
+  10. Automatic Licensing of Downstream Recipients.
 
-Each time you convey a covered work, the recipient automatically
+  Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
 propagate that work, subject to this License.  You are not responsible
 for enforcing compliance by third parties with this License.
 
-An "entity transaction" is a transaction transferring control of an
+  An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
 organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
@@ -448,7 +448,7 @@ give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
 the predecessor has it or can get it with reasonable efforts.
 
-You may not impose any further restrictions on the exercise of the
+  You may not impose any further restrictions on the exercise of the
 rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
@@ -456,13 +456,13 @@ rights granted under this License, and you may not initiate litigation
 any patent claim is infringed by making, using, selling, offering for
 sale, or importing the Program or any portion of it.
 
-11. Patents.
+  11. Patents.
 
-A "contributor" is a copyright holder who authorizes use under this
+  A "contributor" is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based.  The
 work thus licensed is called the contributor's "contributor version".
 
-A contributor's "essential patent claims" are all patent claims
+  A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
@@ -472,19 +472,19 @@ purposes of this definition, "control" includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
 this License.
 
-Each contributor grants you a non-exclusive, worldwide, royalty-free
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
 propagate the contents of its contributor version.
 
-In the following three paragraphs, a "patent license" is any express
+  In the following three paragraphs, a "patent license" is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
 sue for patent infringement).  To "grant" such a patent license to a
 party means to make such an agreement or commitment not to enforce a
 patent against the party.
 
-If you convey a covered work, knowingly relying on a patent license,
+  If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
 publicly available network server or other readily accessible means,
@@ -498,7 +498,7 @@ covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
 country that you have reason to believe are valid.
 
-If, pursuant to or in connection with a single transaction or
+  If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
 receiving the covered work authorizing them to use, propagate, modify
@@ -506,7 +506,7 @@ or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
 work and works based on it.
 
-A patent license is "discriminatory" if it does not include within
+  A patent license is "discriminatory" if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
 specifically granted under this License.  You may not convey a covered
@@ -521,13 +521,13 @@ for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
 or that patent license was granted, prior to 28 March 2007.
 
-Nothing in this License shall be construed as excluding or limiting
+  Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
 otherwise be available to you under applicable patent law.
 
-12. No Surrender of Others' Freedom.
+  12. No Surrender of Others' Freedom.
 
-If conditions are imposed on you (whether by court order, agreement or
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
 excuse you from the conditions of this License.  If you cannot convey a
 covered work so as to satisfy simultaneously your obligations under this
@@ -537,9 +537,9 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-13. Remote Network Interaction; Use with the GNU General Public License.
+  13. Remote Network Interaction; Use with the GNU General Public License.
 
-Notwithstanding any other provision of this License, if you modify the
+  Notwithstanding any other provision of this License, if you modify the
 Program, your modified version must prominently offer all users
 interacting with it remotely through a computer network (if your version
 supports such interaction) an opportunity to receive the Corresponding
@@ -550,7 +550,7 @@ shall include the Corresponding Source for any work covered by version 3
 of the GNU General Public License that is incorporated pursuant to the
 following paragraph.
 
-Notwithstanding any other provision of this License, you have
+  Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
 under version 3 of the GNU General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
@@ -558,14 +558,14 @@ License will continue to apply to the part which is the covered work,
 but the work with which it is combined will remain governed by version
 3 of the GNU General Public License.
 
-14. Revised Versions of this License.
+  14. Revised Versions of this License.
 
-The Free Software Foundation may publish revised and/or new versions of
+  The Free Software Foundation may publish revised and/or new versions of
 the GNU Affero General Public License from time to time.  Such new versions
 will be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the
+  Each version is given a distinguishing version number.  If the
 Program specifies that a certain numbered version of the GNU Affero General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
@@ -574,19 +574,19 @@ Foundation.  If the Program does not specify a version number of the
 GNU Affero General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
-If the Program specifies that a proxy can decide which future
+  If the Program specifies that a proxy can decide which future
 versions of the GNU Affero General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
-Later license versions may give you additional or different
+  Later license versions may give you additional or different
 permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
 later version.
 
-15. Disclaimer of Warranty.
+  15. Disclaimer of Warranty.
 
-THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
 HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
@@ -595,9 +595,9 @@ PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
 ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-16. Limitation of Liability.
+  16. Limitation of Liability.
 
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -607,47 +607,47 @@ PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGES.
 
-17. Interpretation of Sections 15 and 16.
+  17. Interpretation of Sections 15 and 16.
 
-If the disclaimer of warranty and limitation of liability provided
+  If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
- END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
-How to Apply These Terms to Your New Programs
+            How to Apply These Terms to Your New Programs
 
-If you develop a new program, and you want it to be of the greatest
+  If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
 free software which everyone can redistribute and change under these terms.
 
-To do so, attach the following notices to the program.  It is safest
+  To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-<one line to give the program's name and a brief idea of what it does.>
-Copyright (C) <year>  <name of author>
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published
-by the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
 
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If your software can interact with users remotely through a computer
+  If your software can interact with users remotely through a computer
 network, you should also make sure that it provides a way for users to
 get its source.  For example, if your program is a web application, its
 interface could display a "Source" link that leads users to an archive
@@ -655,7 +655,7 @@ of the code.  There are many ways you could offer source, and different
 solutions will be better for different programs; see section 13 for the
 specific requirements.
 
-You should also get your employer (if you work as a programmer) or school,
+  You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU AGPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.

--- a/includes/licenses/Apache-2.0
+++ b/includes/licenses/Apache-2.0
@@ -1,201 +1,202 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-1. Definitions.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
+   1. Definitions.
 
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-END OF TERMS AND CONDITIONS
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-APPENDIX: How to apply the Apache License to your work.
+   END OF TERMS AND CONDITIONS
 
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "[]"
-replaced with your own identifying information. (Don't include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
+   APPENDIX: How to apply the Apache License to your work.
 
-Copyright [yyyy] [name of copyright owner]
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   Copyright [yyyy] [name of copyright owner]
 
-http://www.apache.org/licenses/LICENSE-2.0
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/includes/licenses/CC-BY-4.0
+++ b/includes/licenses/CC-BY-4.0
@@ -33,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-	wiki.creativecommons.org/Considerations_for_licensors
+    wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -48,9 +48,9 @@ exhaustive, and do not form part of our licenses.
      rights in the material. A licensor may make special requests,
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
+     respect those requests where reasonable. More considerations
      for the public:
-	wiki.creativecommons.org/Considerations_for_licensees
+    wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 

--- a/includes/licenses/CC-BY-SA-4.0
+++ b/includes/licenses/CC-BY-SA-4.0
@@ -33,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-	wiki.creativecommons.org/Considerations_for_licensors
+    wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -48,9 +48,9 @@ exhaustive, and do not form part of our licenses.
      rights in the material. A licensor may make special requests,
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
+     respect those requests where reasonable. More considerations
      for the public:
-	wiki.creativecommons.org/Considerations_for_licensees
+    wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
@@ -303,8 +303,8 @@ apply to Your use of the Licensed Material:
      contents in a database in which You have Sui Generis Database
      Rights, then the database in which You have Sui Generis Database
      Rights (but not its individual contents) is Adapted Material,
-
      including for purposes of Section 3(b); and
+
   c. You must comply with the conditions in Section 3(a) if You Share
      all or a substantial portion of the contents of the database.
 

--- a/includes/licenses/CC0-1.0
+++ b/includes/licenses/CC0-1.0
@@ -1,116 +1,121 @@
+Creative Commons Legal Code
+
 CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
 
 Statement of Purpose
 
 The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator and
-subsequent owner(s) (each and all, an "owner") of an original work of
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
 authorship and/or a database (each, a "Work").
 
-Certain owners wish to permanently relinquish those rights to a Work for the
-purpose of contributing to a commons of creative, cultural and scientific
-works ("Commons") that the public can reliably and without fear of later
-claims of infringement build upon, modify, incorporate in other works, reuse
-and redistribute as freely as possible in any form whatsoever and for any
-purposes, including without limitation commercial purposes. These owners may
-contribute to the Commons to promote the ideal of a free culture and the
-further production of creative, cultural and scientific works, or to gain
-reputation or greater distribution for their Work in part through the use and
-efforts of others.
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
 
-For these and/or other purposes and motivations, and without any expectation
-of additional consideration or compensation, the person associating CC0 with a
-Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
-and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
-and publicly distribute the Work under its terms, with knowledge of his or her
-Copyright and Related Rights in the Work and the meaning and intended legal
-effect of CC0 on those rights.
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
 
 1. Copyright and Related Rights. A Work made available under CC0 may be
 protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not limited
-to, the following:
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
 
-  i. the right to reproduce, adapt, distribute, perform, display, communicate,
-  and translate a Work;
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
 
-  ii. moral rights retained by the original author(s) and/or performer(s);
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
 
-  iii. publicity and privacy rights pertaining to a person's image or likeness
-  depicted in a Work;
-
-  iv. rights protecting against unfair competition in regards to a Work,
-  subject to the limitations in paragraph 4(a), below;
-
-  v. rights protecting the extraction, dissemination, use and reuse of data in
-  a Work;
-
-  vi. database rights (such as those arising under Directive 96/9/EC of the
-  European Parliament and of the Council of 11 March 1996 on the legal
-  protection of databases, and under any national implementation thereof,
-  including any amended or successor version of such directive); and
-
-  vii. other similar, equivalent or corresponding rights throughout the world
-  based on applicable law or treaty, and any national implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention of,
-applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
-unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
-and Related Rights and associated claims and causes of action, whether now
-known or unknown (including existing as well as future claims and causes of
-action), in the Work (i) in all territories worldwide, (ii) for the maximum
-duration provided by applicable law or treaty (including future time
-extensions), (iii) in any current or future medium and for any number of
-copies, and (iv) for any purpose whatsoever, including without limitation
-commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
-the Waiver for the benefit of each member of the public at large and to the
-detriment of Affirmer's heirs and successors, fully intending that such Waiver
-shall not be subject to revocation, rescission, cancellation, termination, or
-any other legal or equitable action to disrupt the quiet enjoyment of the Work
-by the public as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason be
-judged legally invalid or ineffective under applicable law, then the Waiver
-shall be preserved to the maximum extent permitted taking into account
-Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
-is so judged Affirmer hereby grants to each affected person a royalty-free,
-non transferable, non sublicensable, non exclusive, irrevocable and
-unconditional license to exercise Affirmer's Copyright and Related Rights in
-the Work (i) in all territories worldwide, (ii) for the maximum duration
-provided by applicable law or treaty (including future time extensions), (iii)
-in any current or future medium and for any number of copies, and (iv) for any
-purpose whatsoever, including without limitation commercial, advertising or
-promotional purposes (the "License"). The License shall be deemed effective as
-of the date CC0 was applied by Affirmer to the Work. Should any part of the
-License for any reason be judged legally invalid or ineffective under
-applicable law, such partial invalidity or ineffectiveness shall not
-invalidate the remainder of the License, and in such case Affirmer hereby
-affirms that he or she will not (i) exercise any of his or her remaining
-Copyright and Related Rights in the Work or (ii) assert any associated claims
-and causes of action with respect to the Work, in either case contrary to
-Affirmer's express Statement of Purpose.
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
 
 4. Limitations and Disclaimers.
 
-  a. No trademark or patent rights held by Affirmer are waived, abandoned,
-  surrendered, licensed or otherwise affected by this document.
-
-  b. Affirmer offers the Work as-is and makes no representations or warranties
-  of any kind concerning the Work, express, implied, statutory or otherwise,
-  including without limitation warranties of title, merchantability, fitness
-  for a particular purpose, non infringement, or the absence of latent or
-  other defects, accuracy, or the present or absence of errors, whether or not
-  discoverable, all to the greatest extent permissible under applicable law.
-
-  c. Affirmer disclaims responsibility for clearing rights of other persons
-  that may apply to the Work or any use thereof, including without limitation
-  any person's Copyright and Related Rights in the Work. Further, Affirmer
-  disclaims responsibility for obtaining any necessary consents, permissions
-  or other rights required for any use of the Work.
-
-  d. Affirmer understands and acknowledges that Creative Commons is not a
-  party to this document and has no duty or obligation with respect to this
-  CC0 or use of the Work.
-
-For more information, please see
-<http://creativecommons.org/publicdomain/zero/1.0/>
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/includes/licenses/GPL-3.0
+++ b/includes/licenses/GPL-3.0
@@ -1,16 +1,16 @@
-GNU GENERAL PUBLIC LICENSE
-   Version 3, 29 June 2007
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-        Preamble
+                            Preamble
 
-The GNU General Public License is a free, copyleft license for
+  The GNU General Public License is a free, copyleft license for
 software and other kinds of works.
 
-The licenses for most software and other practical works are designed
+  The licenses for most software and other practical works are designed
 to take away your freedom to share and change the works.  By contrast,
 the GNU General Public License is intended to guarantee your freedom to
 share and change all versions of a program--to make sure it remains free
@@ -19,35 +19,35 @@ GNU General Public License for most of our software; it applies also to
 any other work released this way by its authors.  You can apply it to
 your programs, too.
 
-When we speak of free software, we are referring to freedom, not
+  When we speak of free software, we are referring to freedom, not
 price.  Our General Public Licenses are designed to make sure that you
 have the freedom to distribute copies of free software (and charge for
 them if you wish), that you receive source code or can get it if you
 want it, that you can change the software or use pieces of it in new
 free programs, and that you know you can do these things.
 
-To protect your rights, we need to prevent others from denying you
+  To protect your rights, we need to prevent others from denying you
 these rights or asking you to surrender the rights.  Therefore, you have
 certain responsibilities if you distribute copies of the software, or if
 you modify it: responsibilities to respect the freedom of others.
 
-For example, if you distribute copies of such a program, whether
+  For example, if you distribute copies of such a program, whether
 gratis or for a fee, you must pass on to the recipients the same
 freedoms that you received.  You must make sure that they, too, receive
 or can get the source code.  And you must show them these terms so they
 know their rights.
 
-Developers that use the GNU GPL protect your rights with two steps:
+  Developers that use the GNU GPL protect your rights with two steps:
 (1) assert copyright on the software, and (2) offer you this License
 giving you legal permission to copy, distribute and/or modify it.
 
-For the developers' and authors' protection, the GPL clearly explains
+  For the developers' and authors' protection, the GPL clearly explains
 that there is no warranty for this free software.  For both users' and
 authors' sake, the GPL requires that modified versions be marked as
 changed, so that their problems will not be attributed erroneously to
 authors of previous versions.
 
-Some devices are designed to deny users access to install or run
+  Some devices are designed to deny users access to install or run
 modified versions of the software inside them, although the manufacturer
 can do so.  This is fundamentally incompatible with the aim of
 protecting users' freedom to change the software.  The systematic
@@ -58,49 +58,49 @@ products.  If such problems arise substantially in other domains, we
 stand ready to extend this provision to those domains in future versions
 of the GPL, as needed to protect the freedom of users.
 
-Finally, every program is threatened constantly by software patents.
+  Finally, every program is threatened constantly by software patents.
 States should not allow patents to restrict development and use of
 software on general-purpose computers, but in those that do, we wish to
 avoid the special danger that patents applied to a free program could
 make it effectively proprietary.  To prevent this, the GPL assures that
 patents cannot be used to render the program non-free.
 
-The precise terms and conditions for copying, distribution and
+  The precise terms and conditions for copying, distribution and
 modification follow.
 
-   TERMS AND CONDITIONS
+                       TERMS AND CONDITIONS
 
-0. Definitions.
+  0. Definitions.
 
-"This License" refers to version 3 of the GNU General Public License.
+  "This License" refers to version 3 of the GNU General Public License.
 
-"Copyright" also means copyright-like laws that apply to other kinds of
+  "Copyright" also means copyright-like laws that apply to other kinds of
 works, such as semiconductor masks.
 
-"The Program" refers to any copyrightable work licensed under this
+  "The Program" refers to any copyrightable work licensed under this
 License.  Each licensee is addressed as "you".  "Licensees" and
 "recipients" may be individuals or organizations.
 
-To "modify" a work means to copy from or adapt all or part of the work
+  To "modify" a work means to copy from or adapt all or part of the work
 in a fashion requiring copyright permission, other than the making of an
 exact copy.  The resulting work is called a "modified version" of the
 earlier work or a work "based on" the earlier work.
 
-A "covered work" means either the unmodified Program or a work based
+  A "covered work" means either the unmodified Program or a work based
 on the Program.
 
-To "propagate" a work means to do anything with it that, without
+  To "propagate" a work means to do anything with it that, without
 permission, would make you directly or secondarily liable for
 infringement under applicable copyright law, except executing it on a
 computer or modifying a private copy.  Propagation includes copying,
 distribution (with or without modification), making available to the
 public, and in some countries other activities as well.
 
-To "convey" a work means any kind of propagation that enables other
+  To "convey" a work means any kind of propagation that enables other
 parties to make or receive copies.  Mere interaction with a user through
 a computer network, with no transfer of a copy, is not conveying.
 
-An interactive user interface displays "Appropriate Legal Notices"
+  An interactive user interface displays "Appropriate Legal Notices"
 to the extent that it includes a convenient and prominently visible
 feature that (1) displays an appropriate copyright notice, and (2)
 tells the user that there is no warranty for the work (except to the
@@ -109,18 +109,18 @@ work under this License, and how to view a copy of this License.  If
 the interface presents a list of user commands or options, such as a
 menu, a prominent item in the list meets this criterion.
 
-1. Source Code.
+  1. Source Code.
 
-The "source code" for a work means the preferred form of the work
+  The "source code" for a work means the preferred form of the work
 for making modifications to it.  "Object code" means any non-source
 form of a work.
 
-A "Standard Interface" means an interface that either is an official
+  A "Standard Interface" means an interface that either is an official
 standard defined by a recognized standards body, or, in the case of
 interfaces specified for a particular programming language, one that
 is widely used among developers working in that language.
 
-The "System Libraries" of an executable work include anything, other
+  The "System Libraries" of an executable work include anything, other
 than the work as a whole, that (a) is included in the normal form of
 packaging a Major Component, but which is not part of that Major
 Component, and (b) serves only to enable use of the work with that
@@ -131,7 +131,7 @@ implementation is available to the public in source code form.  A
 (if any) on which the executable work runs, or a compiler used to
 produce the work, or an object code interpreter used to run it.
 
-The "Corresponding Source" for a work in object code form means all
+  The "Corresponding Source" for a work in object code form means all
 the source code needed to generate, install, and (for an executable
 work) run the object code and to modify the work, including scripts to
 control those activities.  However, it does not include the work's
@@ -144,16 +144,16 @@ linked subprograms that the work is specifically designed to require,
 such as by intimate data communication or control flow between those
 subprograms and other parts of the work.
 
-The Corresponding Source need not include anything that users
+  The Corresponding Source need not include anything that users
 can regenerate automatically from other parts of the Corresponding
 Source.
 
-The Corresponding Source for a work in source code form is that
+  The Corresponding Source for a work in source code form is that
 same work.
 
-2. Basic Permissions.
+  2. Basic Permissions.
 
-All rights granted under this License are granted for the term of
+  All rights granted under this License are granted for the term of
 copyright on the Program, and are irrevocable provided the stated
 conditions are met.  This License explicitly affirms your unlimited
 permission to run the unmodified Program.  The output from running a
@@ -161,7 +161,7 @@ covered work is covered by this License only if the output, given its
 content, constitutes a covered work.  This License acknowledges your
 rights of fair use or other equivalent, as provided by copyright law.
 
-You may make, run and propagate covered works that you do not
+  You may make, run and propagate covered works that you do not
 convey, without conditions so long as your license otherwise remains
 in force.  You may convey covered works to others for the sole purpose
 of having them make modifications exclusively for you, or provide you
@@ -172,19 +172,19 @@ for you must do so exclusively on your behalf, under your direction
 and control, on terms that prohibit them from making any copies of
 your copyrighted material outside their relationship with you.
 
-Conveying under any other circumstances is permitted solely under
+  Conveying under any other circumstances is permitted solely under
 the conditions stated below.  Sublicensing is not allowed; section 10
 makes it unnecessary.
 
-3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
 
-No covered work shall be deemed part of an effective technological
+  No covered work shall be deemed part of an effective technological
 measure under any applicable law fulfilling obligations under article
 11 of the WIPO copyright treaty adopted on 20 December 1996, or
 similar laws prohibiting or restricting circumvention of such
 measures.
 
-When you convey a covered work, you waive any legal power to forbid
+  When you convey a covered work, you waive any legal power to forbid
 circumvention of technological measures to the extent such circumvention
 is effected by exercising rights under this License with respect to
 the covered work, and you disclaim any intention to limit operation or
@@ -192,9 +192,9 @@ modification of the work as a means of enforcing, against the work's
 users, your or third parties' legal rights to forbid circumvention of
 technological measures.
 
-4. Conveying Verbatim Copies.
+  4. Conveying Verbatim Copies.
 
-You may convey verbatim copies of the Program's source code as you
+  You may convey verbatim copies of the Program's source code as you
 receive it, in any medium, provided that you conspicuously and
 appropriately publish on each copy an appropriate copyright notice;
 keep intact all notices stating that this License and any
@@ -202,37 +202,37 @@ non-permissive terms added in accord with section 7 apply to the code;
 keep intact all notices of the absence of any warranty; and give all
 recipients a copy of this License along with the Program.
 
-You may charge any price or no price for each copy that you convey,
+  You may charge any price or no price for each copy that you convey,
 and you may offer support or warranty protection for a fee.
 
-5. Conveying Modified Source Versions.
+  5. Conveying Modified Source Versions.
 
-You may convey a work based on the Program, or the modifications to
+  You may convey a work based on the Program, or the modifications to
 produce it from the Program, in the form of source code under the
 terms of section 4, provided that you also meet all of these conditions:
 
-a) The work must carry prominent notices stating that you modified
-it, and giving a relevant date.
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
 
-b) The work must carry prominent notices stating that it is
-released under this License and any conditions added under section
-7.  This requirement modifies the requirement in section 4 to
-"keep intact all notices".
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
 
-c) You must license the entire work, as a whole, under this
-License to anyone who comes into possession of a copy.  This
-License will therefore apply, along with any applicable section 7
-additional terms, to the whole of the work, and all its parts,
-regardless of how they are packaged.  This License gives no
-permission to license the work in any other way, but it does not
-invalidate such permission if you have separately received it.
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
 
-d) If the work has interactive user interfaces, each must display
-Appropriate Legal Notices; however, if the Program has interactive
-interfaces that do not display Appropriate Legal Notices, your
-work need not make them do so.
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
 
-A compilation of a covered work with other separate and independent
+  A compilation of a covered work with other separate and independent
 works, which are not by their nature extensions of the covered work,
 and which are not combined with it such as to form a larger program,
 in or on a volume of a storage or distribution medium, is called an
@@ -242,59 +242,59 @@ beyond what the individual works permit.  Inclusion of a covered work
 in an aggregate does not cause this License to apply to the other
 parts of the aggregate.
 
-6. Conveying Non-Source Forms.
+  6. Conveying Non-Source Forms.
 
-You may convey a covered work in object code form under the terms
+  You may convey a covered work in object code form under the terms
 of sections 4 and 5, provided that you also convey the
 machine-readable Corresponding Source under the terms of this License,
 in one of these ways:
 
-a) Convey the object code in, or embodied in, a physical product
-(including a physical distribution medium), accompanied by the
-Corresponding Source fixed on a durable physical medium
-customarily used for software interchange.
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
 
-b) Convey the object code in, or embodied in, a physical product
-(including a physical distribution medium), accompanied by a
-written offer, valid for at least three years and valid for as
-long as you offer spare parts or customer support for that product
-model, to give anyone who possesses the object code either (1) a
-copy of the Corresponding Source for all the software in the
-product that is covered by this License, on a durable physical
-medium customarily used for software interchange, for a price no
-more than your reasonable cost of physically performing this
-conveying of source, or (2) access to copy the
-Corresponding Source from a network server at no charge.
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
 
-c) Convey individual copies of the object code with a copy of the
-written offer to provide the Corresponding Source.  This
-alternative is allowed only occasionally and noncommercially, and
-only if you received the object code with such an offer, in accord
-with subsection 6b.
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
 
-d) Convey the object code by offering access from a designated
-place (gratis or for a charge), and offer equivalent access to the
-Corresponding Source in the same way through the same place at no
-further charge.  You need not require recipients to copy the
-Corresponding Source along with the object code.  If the place to
-copy the object code is a network server, the Corresponding Source
-may be on a different server (operated by you or a third party)
-that supports equivalent copying facilities, provided you maintain
-clear directions next to the object code saying where to find the
-Corresponding Source.  Regardless of what server hosts the
-Corresponding Source, you remain obligated to ensure that it is
-available for as long as needed to satisfy these requirements.
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
 
-e) Convey the object code using peer-to-peer transmission, provided
-you inform other peers where the object code and Corresponding
-Source of the work are being offered to the general public at no
-charge under subsection 6d.
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
 
-A separable portion of the object code, whose source code is excluded
+  A separable portion of the object code, whose source code is excluded
 from the Corresponding Source as a System Library, need not be
 included in conveying the object code work.
 
-A "User Product" is either (1) a "consumer product", which means any
+  A "User Product" is either (1) a "consumer product", which means any
 tangible personal property which is normally used for personal, family,
 or household purposes, or (2) anything designed or sold for incorporation
 into a dwelling.  In determining whether a product is a consumer product,
@@ -307,7 +307,7 @@ is a consumer product regardless of whether the product has substantial
 commercial, industrial or non-consumer uses, unless such uses represent
 the only significant mode of use of the product.
 
-"Installation Information" for a User Product means any methods,
+  "Installation Information" for a User Product means any methods,
 procedures, authorization keys, or other information required to install
 and execute modified versions of a covered work in that User Product from
 a modified version of its Corresponding Source.  The information must
@@ -315,7 +315,7 @@ suffice to ensure that the continued functioning of the modified object
 code is in no case prevented or interfered with solely because
 modification has been made.
 
-If you convey an object code work under this section in, or with, or
+  If you convey an object code work under this section in, or with, or
 specifically for use in, a User Product, and the conveying occurs as
 part of a transaction in which the right of possession and use of the
 User Product is transferred to the recipient in perpetuity or for a
@@ -326,7 +326,7 @@ if neither you nor any third party retains the ability to install
 modified object code on the User Product (for example, the work has
 been installed in ROM).
 
-The requirement to provide Installation Information does not include a
+  The requirement to provide Installation Information does not include a
 requirement to continue to provide support service, warranty, or updates
 for a work that has been modified or installed by the recipient, or for
 the User Product in which it has been modified or installed.  Access to a
@@ -334,15 +334,15 @@ network may be denied when the modification itself materially and
 adversely affects the operation of the network or violates the rules and
 protocols for communication across the network.
 
-Corresponding Source conveyed, and Installation Information provided,
+  Corresponding Source conveyed, and Installation Information provided,
 in accord with this section must be in a format that is publicly
 documented (and with an implementation available to the public in
 source code form), and must require no special password or key for
 unpacking, reading or copying.
 
-7. Additional Terms.
+  7. Additional Terms.
 
-"Additional permissions" are terms that supplement the terms of this
+  "Additional permissions" are terms that supplement the terms of this
 License by making exceptions from one or more of its conditions.
 Additional permissions that are applicable to the entire Program shall
 be treated as though they were included in this License, to the extent
@@ -351,41 +351,41 @@ apply only to part of the Program, that part may be used separately
 under those permissions, but the entire Program remains governed by
 this License without regard to the additional permissions.
 
-When you convey a copy of a covered work, you may at your option
+  When you convey a copy of a covered work, you may at your option
 remove any additional permissions from that copy, or from any part of
 it.  (Additional permissions may be written to require their own
 removal in certain cases when you modify the work.)  You may place
 additional permissions on material, added by you to a covered work,
 for which you have or can give appropriate copyright permission.
 
-Notwithstanding any other provision of this License, for material you
+  Notwithstanding any other provision of this License, for material you
 add to a covered work, you may (if authorized by the copyright holders of
 that material) supplement the terms of this License with terms:
 
-a) Disclaiming warranty or limiting liability differently from the
-terms of sections 15 and 16 of this License; or
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
 
-b) Requiring preservation of specified reasonable legal notices or
-author attributions in that material or in the Appropriate Legal
-Notices displayed by works containing it; or
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
 
-c) Prohibiting misrepresentation of the origin of that material, or
-requiring that modified versions of such material be marked in
-reasonable ways as different from the original version; or
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
 
-d) Limiting the use for publicity purposes of names of licensors or
-authors of the material; or
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
 
-e) Declining to grant rights under trademark law for use of some
-trade names, trademarks, or service marks; or
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
 
-f) Requiring indemnification of licensors and authors of that
-material by anyone who conveys the material (or modified versions of
-it) with contractual assumptions of liability to the recipient, for
-any liability that these contractual assumptions directly impose on
-those licensors and authors.
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
 
-All other non-permissive additional terms are considered "further
+  All other non-permissive additional terms are considered "further
 restrictions" within the meaning of section 10.  If the Program as you
 received it, or any part of it, contains a notice stating that it is
 governed by this License along with a term that is a further
@@ -395,46 +395,46 @@ License, you may add to a covered work material governed by the terms
 of that license document, provided that the further restriction does
 not survive such relicensing or conveying.
 
-If you add terms to a covered work in accord with this section, you
+  If you add terms to a covered work in accord with this section, you
 must place, in the relevant source files, a statement of the
 additional terms that apply to those files, or a notice indicating
 where to find the applicable terms.
 
-Additional terms, permissive or non-permissive, may be stated in the
+  Additional terms, permissive or non-permissive, may be stated in the
 form of a separately written license, or stated as exceptions;
 the above requirements apply either way.
 
-8. Termination.
+  8. Termination.
 
-You may not propagate or modify a covered work except as expressly
+  You may not propagate or modify a covered work except as expressly
 provided under this License.  Any attempt otherwise to propagate or
 modify it is void, and will automatically terminate your rights under
 this License (including any patent licenses granted under the third
 paragraph of section 11).
 
-However, if you cease all violation of this License, then your
+  However, if you cease all violation of this License, then your
 license from a particular copyright holder is reinstated (a)
 provisionally, unless and until the copyright holder explicitly and
 finally terminates your license, and (b) permanently, if the copyright
 holder fails to notify you of the violation by some reasonable means
 prior to 60 days after the cessation.
 
-Moreover, your license from a particular copyright holder is
+  Moreover, your license from a particular copyright holder is
 reinstated permanently if the copyright holder notifies you of the
 violation by some reasonable means, this is the first time you have
 received notice of violation of this License (for any work) from that
 copyright holder, and you cure the violation prior to 30 days after
 your receipt of the notice.
 
-Termination of your rights under this section does not terminate the
+  Termination of your rights under this section does not terminate the
 licenses of parties who have received copies or rights from you under
 this License.  If your rights have been terminated and not permanently
 reinstated, you do not qualify to receive new licenses for the same
 material under section 10.
 
-9. Acceptance Not Required for Having Copies.
+  9. Acceptance Not Required for Having Copies.
 
-You are not required to accept this License in order to receive or
+  You are not required to accept this License in order to receive or
 run a copy of the Program.  Ancillary propagation of a covered work
 occurring solely as a consequence of using peer-to-peer transmission
 to receive a copy likewise does not require acceptance.  However,
@@ -443,14 +443,14 @@ modify any covered work.  These actions infringe copyright if you do
 not accept this License.  Therefore, by modifying or propagating a
 covered work, you indicate your acceptance of this License to do so.
 
-10. Automatic Licensing of Downstream Recipients.
+  10. Automatic Licensing of Downstream Recipients.
 
-Each time you convey a covered work, the recipient automatically
+  Each time you convey a covered work, the recipient automatically
 receives a license from the original licensors, to run, modify and
 propagate that work, subject to this License.  You are not responsible
 for enforcing compliance by third parties with this License.
 
-An "entity transaction" is a transaction transferring control of an
+  An "entity transaction" is a transaction transferring control of an
 organization, or substantially all assets of one, or subdividing an
 organization, or merging organizations.  If propagation of a covered
 work results from an entity transaction, each party to that
@@ -460,7 +460,7 @@ give under the previous paragraph, plus a right to possession of the
 Corresponding Source of the work from the predecessor in interest, if
 the predecessor has it or can get it with reasonable efforts.
 
-You may not impose any further restrictions on the exercise of the
+  You may not impose any further restrictions on the exercise of the
 rights granted or affirmed under this License.  For example, you may
 not impose a license fee, royalty, or other charge for exercise of
 rights granted under this License, and you may not initiate litigation
@@ -468,13 +468,13 @@ rights granted under this License, and you may not initiate litigation
 any patent claim is infringed by making, using, selling, offering for
 sale, or importing the Program or any portion of it.
 
-11. Patents.
+  11. Patents.
 
-A "contributor" is a copyright holder who authorizes use under this
+  A "contributor" is a copyright holder who authorizes use under this
 License of the Program or a work on which the Program is based.  The
 work thus licensed is called the contributor's "contributor version".
 
-A contributor's "essential patent claims" are all patent claims
+  A contributor's "essential patent claims" are all patent claims
 owned or controlled by the contributor, whether already acquired or
 hereafter acquired, that would be infringed by some manner, permitted
 by this License, of making, using, or selling its contributor version,
@@ -484,19 +484,19 @@ purposes of this definition, "control" includes the right to grant
 patent sublicenses in a manner consistent with the requirements of
 this License.
 
-Each contributor grants you a non-exclusive, worldwide, royalty-free
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
 patent license under the contributor's essential patent claims, to
 make, use, sell, offer for sale, import and otherwise run, modify and
 propagate the contents of its contributor version.
 
-In the following three paragraphs, a "patent license" is any express
+  In the following three paragraphs, a "patent license" is any express
 agreement or commitment, however denominated, not to enforce a patent
 (such as an express permission to practice a patent or covenant not to
 sue for patent infringement).  To "grant" such a patent license to a
 party means to make such an agreement or commitment not to enforce a
 patent against the party.
 
-If you convey a covered work, knowingly relying on a patent license,
+  If you convey a covered work, knowingly relying on a patent license,
 and the Corresponding Source of the work is not available for anyone
 to copy, free of charge and under the terms of this License, through a
 publicly available network server or other readily accessible means,
@@ -510,7 +510,7 @@ covered work in a country, or your recipient's use of the covered work
 in a country, would infringe one or more identifiable patents in that
 country that you have reason to believe are valid.
 
-If, pursuant to or in connection with a single transaction or
+  If, pursuant to or in connection with a single transaction or
 arrangement, you convey, or propagate by procuring conveyance of, a
 covered work, and grant a patent license to some of the parties
 receiving the covered work authorizing them to use, propagate, modify
@@ -518,7 +518,7 @@ or convey a specific copy of the covered work, then the patent license
 you grant is automatically extended to all recipients of the covered
 work and works based on it.
 
-A patent license is "discriminatory" if it does not include within
+  A patent license is "discriminatory" if it does not include within
 the scope of its coverage, prohibits the exercise of, or is
 conditioned on the non-exercise of one or more of the rights that are
 specifically granted under this License.  You may not convey a covered
@@ -533,13 +533,13 @@ for and in connection with specific products or compilations that
 contain the covered work, unless you entered into that arrangement,
 or that patent license was granted, prior to 28 March 2007.
 
-Nothing in this License shall be construed as excluding or limiting
+  Nothing in this License shall be construed as excluding or limiting
 any implied license or other defenses to infringement that may
 otherwise be available to you under applicable patent law.
 
-12. No Surrender of Others' Freedom.
+  12. No Surrender of Others' Freedom.
 
-If conditions are imposed on you (whether by court order, agreement or
+  If conditions are imposed on you (whether by court order, agreement or
 otherwise) that contradict the conditions of this License, they do not
 excuse you from the conditions of this License.  If you cannot convey a
 covered work so as to satisfy simultaneously your obligations under this
@@ -549,9 +549,9 @@ to collect a royalty for further conveying from those to whom you convey
 the Program, the only way you could satisfy both those terms and this
 License would be to refrain entirely from conveying the Program.
 
-13. Use with the GNU Affero General Public License.
+  13. Use with the GNU Affero General Public License.
 
-Notwithstanding any other provision of this License, you have
+  Notwithstanding any other provision of this License, you have
 permission to link or combine any covered work with a work licensed
 under version 3 of the GNU Affero General Public License into a single
 combined work, and to convey the resulting work.  The terms of this
@@ -560,14 +560,14 @@ but the special requirements of the GNU Affero General Public License,
 section 13, concerning interaction through a network will apply to the
 combination as such.
 
-14. Revised Versions of this License.
+  14. Revised Versions of this License.
 
-The Free Software Foundation may publish revised and/or new versions of
+  The Free Software Foundation may publish revised and/or new versions of
 the GNU General Public License from time to time.  Such new versions will
 be similar in spirit to the present version, but may differ in detail to
 address new problems or concerns.
 
-Each version is given a distinguishing version number.  If the
+  Each version is given a distinguishing version number.  If the
 Program specifies that a certain numbered version of the GNU General
 Public License "or any later version" applies to it, you have the
 option of following the terms and conditions either of that numbered
@@ -576,19 +576,19 @@ Foundation.  If the Program does not specify a version number of the
 GNU General Public License, you may choose any version ever published
 by the Free Software Foundation.
 
-If the Program specifies that a proxy can decide which future
+  If the Program specifies that a proxy can decide which future
 versions of the GNU General Public License can be used, that proxy's
 public statement of acceptance of a version permanently authorizes you
 to choose that version for the Program.
 
-Later license versions may give you additional or different
+  Later license versions may give you additional or different
 permissions.  However, no additional obligations are imposed on any
 author or copyright holder as a result of your choosing to follow a
 later version.
 
-15. Disclaimer of Warranty.
+  15. Disclaimer of Warranty.
 
-THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
 HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
@@ -597,9 +597,9 @@ PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
 ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
 
-16. Limitation of Liability.
+  16. Limitation of Liability.
 
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -609,66 +609,66 @@ PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGES.
 
-17. Interpretation of Sections 15 and 16.
+  17. Interpretation of Sections 15 and 16.
 
-If the disclaimer of warranty and limitation of liability provided
+  If the disclaimer of warranty and limitation of liability provided
 above cannot be given local legal effect according to their terms,
 reviewing courts shall apply local law that most closely approximates
 an absolute waiver of all civil liability in connection with the
 Program, unless a warranty or assumption of liability accompanies a
 copy of the Program in return for a fee.
 
- END OF TERMS AND CONDITIONS
+                     END OF TERMS AND CONDITIONS
 
-How to Apply These Terms to Your New Programs
+            How to Apply These Terms to Your New Programs
 
-If you develop a new program, and you want it to be of the greatest
+  If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it
 free software which everyone can redistribute and change under these terms.
 
-To do so, attach the following notices to the program.  It is safest
+  To do so, attach the following notices to the program.  It is safest
 to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-<one line to give the program's name and a brief idea of what it does.>
-Copyright (C) <year>  <name of author>
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-If the program does terminal interaction, make it output a short
+  If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-<program>  Copyright (C) <year>  <name of author>
-This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-This is free software, and you are welcome to redistribute it
-under certain conditions; type `show c' for details.
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
 
 The hypothetical commands `show w' and `show c' should show the appropriate
 parts of the General Public License.  Of course, your program's commands
 might be different; for a GUI interface, you would use an "about box".
 
-You should also get your employer (if you work as a programmer) or school,
+  You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
-The GNU General Public License does not permit incorporating your program
+  The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/includes/licenses/LGPL-3.0
+++ b/includes/licenses/LGPL-3.0
@@ -1,154 +1,154 @@
-GNU LESSER GENERAL PUBLIC LICENSE
-    Version 3, 29 June 2007
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
 
-This version of the GNU Lesser General Public License incorporates
+  This version of the GNU Lesser General Public License incorporates
 the terms and conditions of version 3 of the GNU General Public
 License, supplemented by the additional permissions listed below.
 
-0. Additional Definitions.
+  0. Additional Definitions.
 
-As used herein, "this License" refers to version 3 of the GNU Lesser
+  As used herein, "this License" refers to version 3 of the GNU Lesser
 General Public License, and the "GNU GPL" refers to version 3 of the GNU
 General Public License.
 
-"The Library" refers to a covered work governed by this License,
+  "The Library" refers to a covered work governed by this License,
 other than an Application or a Combined Work as defined below.
 
-An "Application" is any work that makes use of an interface provided
+  An "Application" is any work that makes use of an interface provided
 by the Library, but which is not otherwise based on the Library.
 Defining a subclass of a class defined by the Library is deemed a mode
 of using an interface provided by the Library.
 
-A "Combined Work" is a work produced by combining or linking an
+  A "Combined Work" is a work produced by combining or linking an
 Application with the Library.  The particular version of the Library
 with which the Combined Work was made is also called the "Linked
 Version".
 
-The "Minimal Corresponding Source" for a Combined Work means the
+  The "Minimal Corresponding Source" for a Combined Work means the
 Corresponding Source for the Combined Work, excluding any source code
 for portions of the Combined Work that, considered in isolation, are
 based on the Application, and not on the Linked Version.
 
-The "Corresponding Application Code" for a Combined Work means the
+  The "Corresponding Application Code" for a Combined Work means the
 object code and/or source code for the Application, including any data
 and utility programs needed for reproducing the Combined Work from the
 Application, but excluding the System Libraries of the Combined Work.
 
-1. Exception to Section 3 of the GNU GPL.
+  1. Exception to Section 3 of the GNU GPL.
 
-You may convey a covered work under sections 3 and 4 of this License
+  You may convey a covered work under sections 3 and 4 of this License
 without being bound by section 3 of the GNU GPL.
 
-2. Conveying Modified Versions.
+  2. Conveying Modified Versions.
 
-If you modify a copy of the Library, and, in your modifications, a
+  If you modify a copy of the Library, and, in your modifications, a
 facility refers to a function or data to be supplied by an Application
 that uses the facility (other than as an argument passed when the
 facility is invoked), then you may convey a copy of the modified
 version:
 
-a) under this License, provided that you make a good faith effort to
-ensure that, in the event an Application does not supply the
-function or data, the facility still operates, and performs
-whatever part of its purpose remains meaningful, or
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
 
-b) under the GNU GPL, with none of the additional permissions of
-this License applicable to that copy.
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
 
-3. Object Code Incorporating Material from Library Header Files.
+  3. Object Code Incorporating Material from Library Header Files.
 
-The object code form of an Application may incorporate material from
+  The object code form of an Application may incorporate material from
 a header file that is part of the Library.  You may convey such object
 code under terms of your choice, provided that, if the incorporated
 material is not limited to numerical parameters, data structure
 layouts and accessors, or small macros, inline functions and templates
 (ten or fewer lines in length), you do both of the following:
 
-a) Give prominent notice with each copy of the object code that the
-Library is used in it and that the Library and its use are
-covered by this License.
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
 
-b) Accompany the object code with a copy of the GNU GPL and this license
-document.
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
 
-4. Combined Works.
+  4. Combined Works.
 
-You may convey a Combined Work under terms of your choice that,
+  You may convey a Combined Work under terms of your choice that,
 taken together, effectively do not restrict modification of the
 portions of the Library contained in the Combined Work and reverse
 engineering for debugging such modifications, if you also do each of
 the following:
 
-a) Give prominent notice with each copy of the Combined Work that
-the Library is used in it and that the Library and its use are
-covered by this License.
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
 
-b) Accompany the Combined Work with a copy of the GNU GPL and this license
-document.
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
 
-c) For a Combined Work that displays copyright notices during
-execution, include the copyright notice for the Library among
-these notices, as well as a reference directing the user to the
-copies of the GNU GPL and this license document.
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
 
-d) Do one of the following:
+   d) Do one of the following:
 
-0) Convey the Minimal Corresponding Source under the terms of this
-License, and the Corresponding Application Code in a form
-suitable for, and under terms that permit, the user to
-recombine or relink the Application with a modified version of
-the Linked Version to produce a modified Combined Work, in the
-manner specified by section 6 of the GNU GPL for conveying
-Corresponding Source.
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
 
-1) Use a suitable shared library mechanism for linking with the
-Library.  A suitable mechanism is one that (a) uses at run time
-a copy of the Library already present on the user's computer
-system, and (b) will operate properly with a modified version
-of the Library that is interface-compatible with the Linked
-Version.
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
 
-e) Provide Installation Information, but only if you would otherwise
-be required to provide such information under section 6 of the
-GNU GPL, and only to the extent that such information is
-necessary to install and execute a modified version of the
-Combined Work produced by recombining or relinking the
-Application with a modified version of the Linked Version. (If
-you use option 4d0, the Installation Information must accompany
-the Minimal Corresponding Source and Corresponding Application
-Code. If you use option 4d1, you must provide the Installation
-Information in the manner specified by section 6 of the GNU GPL
-for conveying Corresponding Source.)
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
 
-5. Combined Libraries.
+  5. Combined Libraries.
 
-You may place library facilities that are a work based on the
+  You may place library facilities that are a work based on the
 Library side by side in a single library together with other library
 facilities that are not Applications and are not covered by this
 License, and convey such a combined library under terms of your
 choice, if you do both of the following:
 
-a) Accompany the combined library with a copy of the same work based
-on the Library, uncombined with any other library facilities,
-conveyed under the terms of this License.
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
 
-b) Give prominent notice with the combined library that part of it
-is a work based on the Library, and explaining where to find the
-accompanying uncombined form of the same work.
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
 
-6. Revised Versions of the GNU Lesser General Public License.
+  6. Revised Versions of the GNU Lesser General Public License.
 
-The Free Software Foundation may publish revised and/or new versions
+  The Free Software Foundation may publish revised and/or new versions
 of the GNU Lesser General Public License from time to time. Such new
 versions will be similar in spirit to the present version, but may
 differ in detail to address new problems or concerns.
 
-Each version is given a distinguishing version number. If the
+  Each version is given a distinguishing version number. If the
 Library as you received it specifies that a certain numbered version
 of the GNU Lesser General Public License "or any later version"
 applies to it, you have the option of following the terms and
@@ -158,7 +158,7 @@ received it does not specify a version number of the GNU Lesser
 General Public License, you may choose any version of the GNU Lesser
 General Public License ever published by the Free Software Foundation.
 
-If the Library as you received it specifies that a proxy can decide
+  If the Library as you received it specifies that a proxy can decide
 whether future versions of the GNU Lesser General Public License shall
 apply, that proxy's public statement of acceptance of any version is
 permanent authorization for you to choose that version for the

--- a/tests/__snapshots__/test_license.ambr
+++ b/tests/__snapshots__/test_license.ambr
@@ -1,38 +1,38 @@
 # serializer version: 1
 # name: test_license[AGPL-3.0]
   '''
-  GNU AFFERO GENERAL PUBLIC LICENSE
-     Version 3, 19 November 2007
+                      GNU AFFERO GENERAL PUBLIC LICENSE
+                         Version 3, 19 November 2007
   
-  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-  Everyone is permitted to copy and distribute verbatim copies
-  of this license document, but changing it is not allowed.
+   Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+   Everyone is permitted to copy and distribute verbatim copies
+   of this license document, but changing it is not allowed.
   
-          Preamble
+                              Preamble
   
-  The GNU Affero General Public License is a free, copyleft license for
+    The GNU Affero General Public License is a free, copyleft license for
   software and other kinds of works, specifically designed to ensure
   cooperation with the community in the case of network server software.
   
-  The licenses for most software and other practical works are designed
+    The licenses for most software and other practical works are designed
   to take away your freedom to share and change the works.  By contrast,
   our General Public Licenses are intended to guarantee your freedom to
   share and change all versions of a program--to make sure it remains free
   software for all its users.
   
-  When we speak of free software, we are referring to freedom, not
+    When we speak of free software, we are referring to freedom, not
   price.  Our General Public Licenses are designed to make sure that you
   have the freedom to distribute copies of free software (and charge for
   them if you wish), that you receive source code or can get it if you
   want it, that you can change the software or use pieces of it in new
   free programs, and that you know you can do these things.
   
-  Developers that use our General Public Licenses protect your rights
+    Developers that use our General Public Licenses protect your rights
   with two steps: (1) assert copyright on the software, and (2) offer
   you this License which gives you legal permission to copy, distribute
   and/or modify the software.
   
-  A secondary benefit of defending all users' freedom is that
+    A secondary benefit of defending all users' freedom is that
   improvements made in alternate versions of the program, if they
   receive widespread use, become available for other developers to
   incorporate.  Many developers of free software are heartened and
@@ -42,7 +42,7 @@
   letting the public access it on a server without ever releasing its
   source code to the public.
   
-  The GNU Affero General Public License is designed specifically to
+    The GNU Affero General Public License is designed specifically to
   ensure that, in such cases, the modified source code becomes available
   to the community.  It requires the operator of a network server to
   provide the source code of the modified version running there to the
@@ -50,48 +50,48 @@
   a publicly accessible server, gives the public access to the source
   code of the modified version.
   
-  An older license, called the Affero General Public License and
+    An older license, called the Affero General Public License and
   published by Affero, was designed to accomplish similar goals.  This is
   a different license, not a version of the Affero GPL, but Affero has
   released a new version of the Affero GPL which permits relicensing under
   this license.
   
-  The precise terms and conditions for copying, distribution and
+    The precise terms and conditions for copying, distribution and
   modification follow.
   
-     TERMS AND CONDITIONS
+                         TERMS AND CONDITIONS
   
-  0. Definitions.
+    0. Definitions.
   
-  "This License" refers to version 3 of the GNU Affero General Public License.
+    "This License" refers to version 3 of the GNU Affero General Public License.
   
-  "Copyright" also means copyright-like laws that apply to other kinds of
+    "Copyright" also means copyright-like laws that apply to other kinds of
   works, such as semiconductor masks.
   
-  "The Program" refers to any copyrightable work licensed under this
+    "The Program" refers to any copyrightable work licensed under this
   License.  Each licensee is addressed as "you".  "Licensees" and
   "recipients" may be individuals or organizations.
   
-  To "modify" a work means to copy from or adapt all or part of the work
+    To "modify" a work means to copy from or adapt all or part of the work
   in a fashion requiring copyright permission, other than the making of an
   exact copy.  The resulting work is called a "modified version" of the
   earlier work or a work "based on" the earlier work.
   
-  A "covered work" means either the unmodified Program or a work based
+    A "covered work" means either the unmodified Program or a work based
   on the Program.
   
-  To "propagate" a work means to do anything with it that, without
+    To "propagate" a work means to do anything with it that, without
   permission, would make you directly or secondarily liable for
   infringement under applicable copyright law, except executing it on a
   computer or modifying a private copy.  Propagation includes copying,
   distribution (with or without modification), making available to the
   public, and in some countries other activities as well.
   
-  To "convey" a work means any kind of propagation that enables other
+    To "convey" a work means any kind of propagation that enables other
   parties to make or receive copies.  Mere interaction with a user through
   a computer network, with no transfer of a copy, is not conveying.
   
-  An interactive user interface displays "Appropriate Legal Notices"
+    An interactive user interface displays "Appropriate Legal Notices"
   to the extent that it includes a convenient and prominently visible
   feature that (1) displays an appropriate copyright notice, and (2)
   tells the user that there is no warranty for the work (except to the
@@ -100,18 +100,18 @@
   the interface presents a list of user commands or options, such as a
   menu, a prominent item in the list meets this criterion.
   
-  1. Source Code.
+    1. Source Code.
   
-  The "source code" for a work means the preferred form of the work
+    The "source code" for a work means the preferred form of the work
   for making modifications to it.  "Object code" means any non-source
   form of a work.
   
-  A "Standard Interface" means an interface that either is an official
+    A "Standard Interface" means an interface that either is an official
   standard defined by a recognized standards body, or, in the case of
   interfaces specified for a particular programming language, one that
   is widely used among developers working in that language.
   
-  The "System Libraries" of an executable work include anything, other
+    The "System Libraries" of an executable work include anything, other
   than the work as a whole, that (a) is included in the normal form of
   packaging a Major Component, but which is not part of that Major
   Component, and (b) serves only to enable use of the work with that
@@ -122,7 +122,7 @@
   (if any) on which the executable work runs, or a compiler used to
   produce the work, or an object code interpreter used to run it.
   
-  The "Corresponding Source" for a work in object code form means all
+    The "Corresponding Source" for a work in object code form means all
   the source code needed to generate, install, and (for an executable
   work) run the object code and to modify the work, including scripts to
   control those activities.  However, it does not include the work's
@@ -135,16 +135,16 @@
   such as by intimate data communication or control flow between those
   subprograms and other parts of the work.
   
-  The Corresponding Source need not include anything that users
+    The Corresponding Source need not include anything that users
   can regenerate automatically from other parts of the Corresponding
   Source.
   
-  The Corresponding Source for a work in source code form is that
+    The Corresponding Source for a work in source code form is that
   same work.
   
-  2. Basic Permissions.
+    2. Basic Permissions.
   
-  All rights granted under this License are granted for the term of
+    All rights granted under this License are granted for the term of
   copyright on the Program, and are irrevocable provided the stated
   conditions are met.  This License explicitly affirms your unlimited
   permission to run the unmodified Program.  The output from running a
@@ -152,7 +152,7 @@
   content, constitutes a covered work.  This License acknowledges your
   rights of fair use or other equivalent, as provided by copyright law.
   
-  You may make, run and propagate covered works that you do not
+    You may make, run and propagate covered works that you do not
   convey, without conditions so long as your license otherwise remains
   in force.  You may convey covered works to others for the sole purpose
   of having them make modifications exclusively for you, or provide you
@@ -163,19 +163,19 @@
   and control, on terms that prohibit them from making any copies of
   your copyrighted material outside their relationship with you.
   
-  Conveying under any other circumstances is permitted solely under
+    Conveying under any other circumstances is permitted solely under
   the conditions stated below.  Sublicensing is not allowed; section 10
   makes it unnecessary.
   
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+    3. Protecting Users' Legal Rights From Anti-Circumvention Law.
   
-  No covered work shall be deemed part of an effective technological
+    No covered work shall be deemed part of an effective technological
   measure under any applicable law fulfilling obligations under article
   11 of the WIPO copyright treaty adopted on 20 December 1996, or
   similar laws prohibiting or restricting circumvention of such
   measures.
   
-  When you convey a covered work, you waive any legal power to forbid
+    When you convey a covered work, you waive any legal power to forbid
   circumvention of technological measures to the extent such circumvention
   is effected by exercising rights under this License with respect to
   the covered work, and you disclaim any intention to limit operation or
@@ -183,9 +183,9 @@
   users, your or third parties' legal rights to forbid circumvention of
   technological measures.
   
-  4. Conveying Verbatim Copies.
+    4. Conveying Verbatim Copies.
   
-  You may convey verbatim copies of the Program's source code as you
+    You may convey verbatim copies of the Program's source code as you
   receive it, in any medium, provided that you conspicuously and
   appropriately publish on each copy an appropriate copyright notice;
   keep intact all notices stating that this License and any
@@ -193,37 +193,37 @@
   keep intact all notices of the absence of any warranty; and give all
   recipients a copy of this License along with the Program.
   
-  You may charge any price or no price for each copy that you convey,
+    You may charge any price or no price for each copy that you convey,
   and you may offer support or warranty protection for a fee.
   
-  5. Conveying Modified Source Versions.
+    5. Conveying Modified Source Versions.
   
-  You may convey a work based on the Program, or the modifications to
+    You may convey a work based on the Program, or the modifications to
   produce it from the Program, in the form of source code under the
   terms of section 4, provided that you also meet all of these conditions:
   
-  a) The work must carry prominent notices stating that you modified
-  it, and giving a relevant date.
+      a) The work must carry prominent notices stating that you modified
+      it, and giving a relevant date.
   
-  b) The work must carry prominent notices stating that it is
-  released under this License and any conditions added under section
-  7.  This requirement modifies the requirement in section 4 to
-  "keep intact all notices".
+      b) The work must carry prominent notices stating that it is
+      released under this License and any conditions added under section
+      7.  This requirement modifies the requirement in section 4 to
+      "keep intact all notices".
   
-  c) You must license the entire work, as a whole, under this
-  License to anyone who comes into possession of a copy.  This
-  License will therefore apply, along with any applicable section 7
-  additional terms, to the whole of the work, and all its parts,
-  regardless of how they are packaged.  This License gives no
-  permission to license the work in any other way, but it does not
-  invalidate such permission if you have separately received it.
+      c) You must license the entire work, as a whole, under this
+      License to anyone who comes into possession of a copy.  This
+      License will therefore apply, along with any applicable section 7
+      additional terms, to the whole of the work, and all its parts,
+      regardless of how they are packaged.  This License gives no
+      permission to license the work in any other way, but it does not
+      invalidate such permission if you have separately received it.
   
-  d) If the work has interactive user interfaces, each must display
-  Appropriate Legal Notices; however, if the Program has interactive
-  interfaces that do not display Appropriate Legal Notices, your
-  work need not make them do so.
+      d) If the work has interactive user interfaces, each must display
+      Appropriate Legal Notices; however, if the Program has interactive
+      interfaces that do not display Appropriate Legal Notices, your
+      work need not make them do so.
   
-  A compilation of a covered work with other separate and independent
+    A compilation of a covered work with other separate and independent
   works, which are not by their nature extensions of the covered work,
   and which are not combined with it such as to form a larger program,
   in or on a volume of a storage or distribution medium, is called an
@@ -233,59 +233,59 @@
   in an aggregate does not cause this License to apply to the other
   parts of the aggregate.
   
-  6. Conveying Non-Source Forms.
+    6. Conveying Non-Source Forms.
   
-  You may convey a covered work in object code form under the terms
+    You may convey a covered work in object code form under the terms
   of sections 4 and 5, provided that you also convey the
   machine-readable Corresponding Source under the terms of this License,
   in one of these ways:
   
-  a) Convey the object code in, or embodied in, a physical product
-  (including a physical distribution medium), accompanied by the
-  Corresponding Source fixed on a durable physical medium
-  customarily used for software interchange.
+      a) Convey the object code in, or embodied in, a physical product
+      (including a physical distribution medium), accompanied by the
+      Corresponding Source fixed on a durable physical medium
+      customarily used for software interchange.
   
-  b) Convey the object code in, or embodied in, a physical product
-  (including a physical distribution medium), accompanied by a
-  written offer, valid for at least three years and valid for as
-  long as you offer spare parts or customer support for that product
-  model, to give anyone who possesses the object code either (1) a
-  copy of the Corresponding Source for all the software in the
-  product that is covered by this License, on a durable physical
-  medium customarily used for software interchange, for a price no
-  more than your reasonable cost of physically performing this
-  conveying of source, or (2) access to copy the
-  Corresponding Source from a network server at no charge.
+      b) Convey the object code in, or embodied in, a physical product
+      (including a physical distribution medium), accompanied by a
+      written offer, valid for at least three years and valid for as
+      long as you offer spare parts or customer support for that product
+      model, to give anyone who possesses the object code either (1) a
+      copy of the Corresponding Source for all the software in the
+      product that is covered by this License, on a durable physical
+      medium customarily used for software interchange, for a price no
+      more than your reasonable cost of physically performing this
+      conveying of source, or (2) access to copy the
+      Corresponding Source from a network server at no charge.
   
-  c) Convey individual copies of the object code with a copy of the
-  written offer to provide the Corresponding Source.  This
-  alternative is allowed only occasionally and noncommercially, and
-  only if you received the object code with such an offer, in accord
-  with subsection 6b.
+      c) Convey individual copies of the object code with a copy of the
+      written offer to provide the Corresponding Source.  This
+      alternative is allowed only occasionally and noncommercially, and
+      only if you received the object code with such an offer, in accord
+      with subsection 6b.
   
-  d) Convey the object code by offering access from a designated
-  place (gratis or for a charge), and offer equivalent access to the
-  Corresponding Source in the same way through the same place at no
-  further charge.  You need not require recipients to copy the
-  Corresponding Source along with the object code.  If the place to
-  copy the object code is a network server, the Corresponding Source
-  may be on a different server (operated by you or a third party)
-  that supports equivalent copying facilities, provided you maintain
-  clear directions next to the object code saying where to find the
-  Corresponding Source.  Regardless of what server hosts the
-  Corresponding Source, you remain obligated to ensure that it is
-  available for as long as needed to satisfy these requirements.
+      d) Convey the object code by offering access from a designated
+      place (gratis or for a charge), and offer equivalent access to the
+      Corresponding Source in the same way through the same place at no
+      further charge.  You need not require recipients to copy the
+      Corresponding Source along with the object code.  If the place to
+      copy the object code is a network server, the Corresponding Source
+      may be on a different server (operated by you or a third party)
+      that supports equivalent copying facilities, provided you maintain
+      clear directions next to the object code saying where to find the
+      Corresponding Source.  Regardless of what server hosts the
+      Corresponding Source, you remain obligated to ensure that it is
+      available for as long as needed to satisfy these requirements.
   
-  e) Convey the object code using peer-to-peer transmission, provided
-  you inform other peers where the object code and Corresponding
-  Source of the work are being offered to the general public at no
-  charge under subsection 6d.
+      e) Convey the object code using peer-to-peer transmission, provided
+      you inform other peers where the object code and Corresponding
+      Source of the work are being offered to the general public at no
+      charge under subsection 6d.
   
-  A separable portion of the object code, whose source code is excluded
+    A separable portion of the object code, whose source code is excluded
   from the Corresponding Source as a System Library, need not be
   included in conveying the object code work.
   
-  A "User Product" is either (1) a "consumer product", which means any
+    A "User Product" is either (1) a "consumer product", which means any
   tangible personal property which is normally used for personal, family,
   or household purposes, or (2) anything designed or sold for incorporation
   into a dwelling.  In determining whether a product is a consumer product,
@@ -298,7 +298,7 @@
   commercial, industrial or non-consumer uses, unless such uses represent
   the only significant mode of use of the product.
   
-  "Installation Information" for a User Product means any methods,
+    "Installation Information" for a User Product means any methods,
   procedures, authorization keys, or other information required to install
   and execute modified versions of a covered work in that User Product from
   a modified version of its Corresponding Source.  The information must
@@ -306,7 +306,7 @@
   code is in no case prevented or interfered with solely because
   modification has been made.
   
-  If you convey an object code work under this section in, or with, or
+    If you convey an object code work under this section in, or with, or
   specifically for use in, a User Product, and the conveying occurs as
   part of a transaction in which the right of possession and use of the
   User Product is transferred to the recipient in perpetuity or for a
@@ -317,7 +317,7 @@
   modified object code on the User Product (for example, the work has
   been installed in ROM).
   
-  The requirement to provide Installation Information does not include a
+    The requirement to provide Installation Information does not include a
   requirement to continue to provide support service, warranty, or updates
   for a work that has been modified or installed by the recipient, or for
   the User Product in which it has been modified or installed.  Access to a
@@ -325,15 +325,15 @@
   adversely affects the operation of the network or violates the rules and
   protocols for communication across the network.
   
-  Corresponding Source conveyed, and Installation Information provided,
+    Corresponding Source conveyed, and Installation Information provided,
   in accord with this section must be in a format that is publicly
   documented (and with an implementation available to the public in
   source code form), and must require no special password or key for
   unpacking, reading or copying.
   
-  7. Additional Terms.
+    7. Additional Terms.
   
-  "Additional permissions" are terms that supplement the terms of this
+    "Additional permissions" are terms that supplement the terms of this
   License by making exceptions from one or more of its conditions.
   Additional permissions that are applicable to the entire Program shall
   be treated as though they were included in this License, to the extent
@@ -342,41 +342,41 @@
   under those permissions, but the entire Program remains governed by
   this License without regard to the additional permissions.
   
-  When you convey a copy of a covered work, you may at your option
+    When you convey a copy of a covered work, you may at your option
   remove any additional permissions from that copy, or from any part of
   it.  (Additional permissions may be written to require their own
   removal in certain cases when you modify the work.)  You may place
   additional permissions on material, added by you to a covered work,
   for which you have or can give appropriate copyright permission.
   
-  Notwithstanding any other provision of this License, for material you
+    Notwithstanding any other provision of this License, for material you
   add to a covered work, you may (if authorized by the copyright holders of
   that material) supplement the terms of this License with terms:
   
-  a) Disclaiming warranty or limiting liability differently from the
-  terms of sections 15 and 16 of this License; or
+      a) Disclaiming warranty or limiting liability differently from the
+      terms of sections 15 and 16 of this License; or
   
-  b) Requiring preservation of specified reasonable legal notices or
-  author attributions in that material or in the Appropriate Legal
-  Notices displayed by works containing it; or
+      b) Requiring preservation of specified reasonable legal notices or
+      author attributions in that material or in the Appropriate Legal
+      Notices displayed by works containing it; or
   
-  c) Prohibiting misrepresentation of the origin of that material, or
-  requiring that modified versions of such material be marked in
-  reasonable ways as different from the original version; or
+      c) Prohibiting misrepresentation of the origin of that material, or
+      requiring that modified versions of such material be marked in
+      reasonable ways as different from the original version; or
   
-  d) Limiting the use for publicity purposes of names of licensors or
-  authors of the material; or
+      d) Limiting the use for publicity purposes of names of licensors or
+      authors of the material; or
   
-  e) Declining to grant rights under trademark law for use of some
-  trade names, trademarks, or service marks; or
+      e) Declining to grant rights under trademark law for use of some
+      trade names, trademarks, or service marks; or
   
-  f) Requiring indemnification of licensors and authors of that
-  material by anyone who conveys the material (or modified versions of
-  it) with contractual assumptions of liability to the recipient, for
-  any liability that these contractual assumptions directly impose on
-  those licensors and authors.
+      f) Requiring indemnification of licensors and authors of that
+      material by anyone who conveys the material (or modified versions of
+      it) with contractual assumptions of liability to the recipient, for
+      any liability that these contractual assumptions directly impose on
+      those licensors and authors.
   
-  All other non-permissive additional terms are considered "further
+    All other non-permissive additional terms are considered "further
   restrictions" within the meaning of section 10.  If the Program as you
   received it, or any part of it, contains a notice stating that it is
   governed by this License along with a term that is a further
@@ -386,46 +386,46 @@
   of that license document, provided that the further restriction does
   not survive such relicensing or conveying.
   
-  If you add terms to a covered work in accord with this section, you
+    If you add terms to a covered work in accord with this section, you
   must place, in the relevant source files, a statement of the
   additional terms that apply to those files, or a notice indicating
   where to find the applicable terms.
   
-  Additional terms, permissive or non-permissive, may be stated in the
+    Additional terms, permissive or non-permissive, may be stated in the
   form of a separately written license, or stated as exceptions;
   the above requirements apply either way.
   
-  8. Termination.
+    8. Termination.
   
-  You may not propagate or modify a covered work except as expressly
+    You may not propagate or modify a covered work except as expressly
   provided under this License.  Any attempt otherwise to propagate or
   modify it is void, and will automatically terminate your rights under
   this License (including any patent licenses granted under the third
   paragraph of section 11).
   
-  However, if you cease all violation of this License, then your
+    However, if you cease all violation of this License, then your
   license from a particular copyright holder is reinstated (a)
   provisionally, unless and until the copyright holder explicitly and
   finally terminates your license, and (b) permanently, if the copyright
   holder fails to notify you of the violation by some reasonable means
   prior to 60 days after the cessation.
   
-  Moreover, your license from a particular copyright holder is
+    Moreover, your license from a particular copyright holder is
   reinstated permanently if the copyright holder notifies you of the
   violation by some reasonable means, this is the first time you have
   received notice of violation of this License (for any work) from that
   copyright holder, and you cure the violation prior to 30 days after
   your receipt of the notice.
   
-  Termination of your rights under this section does not terminate the
+    Termination of your rights under this section does not terminate the
   licenses of parties who have received copies or rights from you under
   this License.  If your rights have been terminated and not permanently
   reinstated, you do not qualify to receive new licenses for the same
   material under section 10.
   
-  9. Acceptance Not Required for Having Copies.
+    9. Acceptance Not Required for Having Copies.
   
-  You are not required to accept this License in order to receive or
+    You are not required to accept this License in order to receive or
   run a copy of the Program.  Ancillary propagation of a covered work
   occurring solely as a consequence of using peer-to-peer transmission
   to receive a copy likewise does not require acceptance.  However,
@@ -434,14 +434,14 @@
   not accept this License.  Therefore, by modifying or propagating a
   covered work, you indicate your acceptance of this License to do so.
   
-  10. Automatic Licensing of Downstream Recipients.
+    10. Automatic Licensing of Downstream Recipients.
   
-  Each time you convey a covered work, the recipient automatically
+    Each time you convey a covered work, the recipient automatically
   receives a license from the original licensors, to run, modify and
   propagate that work, subject to this License.  You are not responsible
   for enforcing compliance by third parties with this License.
   
-  An "entity transaction" is a transaction transferring control of an
+    An "entity transaction" is a transaction transferring control of an
   organization, or substantially all assets of one, or subdividing an
   organization, or merging organizations.  If propagation of a covered
   work results from an entity transaction, each party to that
@@ -451,7 +451,7 @@
   Corresponding Source of the work from the predecessor in interest, if
   the predecessor has it or can get it with reasonable efforts.
   
-  You may not impose any further restrictions on the exercise of the
+    You may not impose any further restrictions on the exercise of the
   rights granted or affirmed under this License.  For example, you may
   not impose a license fee, royalty, or other charge for exercise of
   rights granted under this License, and you may not initiate litigation
@@ -459,13 +459,13 @@
   any patent claim is infringed by making, using, selling, offering for
   sale, or importing the Program or any portion of it.
   
-  11. Patents.
+    11. Patents.
   
-  A "contributor" is a copyright holder who authorizes use under this
+    A "contributor" is a copyright holder who authorizes use under this
   License of the Program or a work on which the Program is based.  The
   work thus licensed is called the contributor's "contributor version".
   
-  A contributor's "essential patent claims" are all patent claims
+    A contributor's "essential patent claims" are all patent claims
   owned or controlled by the contributor, whether already acquired or
   hereafter acquired, that would be infringed by some manner, permitted
   by this License, of making, using, or selling its contributor version,
@@ -475,19 +475,19 @@
   patent sublicenses in a manner consistent with the requirements of
   this License.
   
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
+    Each contributor grants you a non-exclusive, worldwide, royalty-free
   patent license under the contributor's essential patent claims, to
   make, use, sell, offer for sale, import and otherwise run, modify and
   propagate the contents of its contributor version.
   
-  In the following three paragraphs, a "patent license" is any express
+    In the following three paragraphs, a "patent license" is any express
   agreement or commitment, however denominated, not to enforce a patent
   (such as an express permission to practice a patent or covenant not to
   sue for patent infringement).  To "grant" such a patent license to a
   party means to make such an agreement or commitment not to enforce a
   patent against the party.
   
-  If you convey a covered work, knowingly relying on a patent license,
+    If you convey a covered work, knowingly relying on a patent license,
   and the Corresponding Source of the work is not available for anyone
   to copy, free of charge and under the terms of this License, through a
   publicly available network server or other readily accessible means,
@@ -501,7 +501,7 @@
   in a country, would infringe one or more identifiable patents in that
   country that you have reason to believe are valid.
   
-  If, pursuant to or in connection with a single transaction or
+    If, pursuant to or in connection with a single transaction or
   arrangement, you convey, or propagate by procuring conveyance of, a
   covered work, and grant a patent license to some of the parties
   receiving the covered work authorizing them to use, propagate, modify
@@ -509,7 +509,7 @@
   you grant is automatically extended to all recipients of the covered
   work and works based on it.
   
-  A patent license is "discriminatory" if it does not include within
+    A patent license is "discriminatory" if it does not include within
   the scope of its coverage, prohibits the exercise of, or is
   conditioned on the non-exercise of one or more of the rights that are
   specifically granted under this License.  You may not convey a covered
@@ -524,13 +524,13 @@
   contain the covered work, unless you entered into that arrangement,
   or that patent license was granted, prior to 28 March 2007.
   
-  Nothing in this License shall be construed as excluding or limiting
+    Nothing in this License shall be construed as excluding or limiting
   any implied license or other defenses to infringement that may
   otherwise be available to you under applicable patent law.
   
-  12. No Surrender of Others' Freedom.
+    12. No Surrender of Others' Freedom.
   
-  If conditions are imposed on you (whether by court order, agreement or
+    If conditions are imposed on you (whether by court order, agreement or
   otherwise) that contradict the conditions of this License, they do not
   excuse you from the conditions of this License.  If you cannot convey a
   covered work so as to satisfy simultaneously your obligations under this
@@ -540,9 +540,9 @@
   the Program, the only way you could satisfy both those terms and this
   License would be to refrain entirely from conveying the Program.
   
-  13. Remote Network Interaction; Use with the GNU General Public License.
+    13. Remote Network Interaction; Use with the GNU General Public License.
   
-  Notwithstanding any other provision of this License, if you modify the
+    Notwithstanding any other provision of this License, if you modify the
   Program, your modified version must prominently offer all users
   interacting with it remotely through a computer network (if your version
   supports such interaction) an opportunity to receive the Corresponding
@@ -553,7 +553,7 @@
   of the GNU General Public License that is incorporated pursuant to the
   following paragraph.
   
-  Notwithstanding any other provision of this License, you have
+    Notwithstanding any other provision of this License, you have
   permission to link or combine any covered work with a work licensed
   under version 3 of the GNU General Public License into a single
   combined work, and to convey the resulting work.  The terms of this
@@ -561,14 +561,14 @@
   but the work with which it is combined will remain governed by version
   3 of the GNU General Public License.
   
-  14. Revised Versions of this License.
+    14. Revised Versions of this License.
   
-  The Free Software Foundation may publish revised and/or new versions of
+    The Free Software Foundation may publish revised and/or new versions of
   the GNU Affero General Public License from time to time.  Such new versions
   will be similar in spirit to the present version, but may differ in detail to
   address new problems or concerns.
   
-  Each version is given a distinguishing version number.  If the
+    Each version is given a distinguishing version number.  If the
   Program specifies that a certain numbered version of the GNU Affero General
   Public License "or any later version" applies to it, you have the
   option of following the terms and conditions either of that numbered
@@ -577,19 +577,19 @@
   GNU Affero General Public License, you may choose any version ever published
   by the Free Software Foundation.
   
-  If the Program specifies that a proxy can decide which future
+    If the Program specifies that a proxy can decide which future
   versions of the GNU Affero General Public License can be used, that proxy's
   public statement of acceptance of a version permanently authorizes you
   to choose that version for the Program.
   
-  Later license versions may give you additional or different
+    Later license versions may give you additional or different
   permissions.  However, no additional obligations are imposed on any
   author or copyright holder as a result of your choosing to follow a
   later version.
   
-  15. Disclaimer of Warranty.
+    15. Disclaimer of Warranty.
   
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+    THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
   APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
   HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
   OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
@@ -598,9 +598,9 @@
   IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
   ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
   
-  16. Limitation of Liability.
+    16. Limitation of Liability.
   
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+    IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
   WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
   THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
   GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -610,47 +610,47 @@
   EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
   SUCH DAMAGES.
   
-  17. Interpretation of Sections 15 and 16.
+    17. Interpretation of Sections 15 and 16.
   
-  If the disclaimer of warranty and limitation of liability provided
+    If the disclaimer of warranty and limitation of liability provided
   above cannot be given local legal effect according to their terms,
   reviewing courts shall apply local law that most closely approximates
   an absolute waiver of all civil liability in connection with the
   Program, unless a warranty or assumption of liability accompanies a
   copy of the Program in return for a fee.
   
-   END OF TERMS AND CONDITIONS
+                       END OF TERMS AND CONDITIONS
   
-  How to Apply These Terms to Your New Programs
+              How to Apply These Terms to Your New Programs
   
-  If you develop a new program, and you want it to be of the greatest
+    If you develop a new program, and you want it to be of the greatest
   possible use to the public, the best way to achieve this is to make it
   free software which everyone can redistribute and change under these terms.
   
-  To do so, attach the following notices to the program.  It is safest
+    To do so, attach the following notices to the program.  It is safest
   to attach them to the start of each source file to most effectively
   state the exclusion of warranty; and each file should have at least
   the "copyright" line and a pointer to where the full notice is found.
   
-  <one line to give the program's name and a brief idea of what it does.>
-  Copyright (C) <year>  <name of author>
+      <one line to give the program's name and a brief idea of what it does.>
+      Copyright (C) <year>  <name of author>
   
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU Affero General Public License as published
-  by the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU Affero General Public License as published by
+      the Free Software Foundation, either version 3 of the License, or
+      (at your option) any later version.
   
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU Affero General Public License for more details.
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU Affero General Public License for more details.
   
-  You should have received a copy of the GNU Affero General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+      You should have received a copy of the GNU Affero General Public License
+      along with this program.  If not, see <https://www.gnu.org/licenses/>.
   
   Also add information on how to contact you by electronic and paper mail.
   
-  If your software can interact with users remotely through a computer
+    If your software can interact with users remotely through a computer
   network, you should also make sure that it provides a way for users to
   get its source.  For example, if your program is a web application, its
   interface could display a "Source" link that leads users to an archive
@@ -658,216 +658,217 @@
   solutions will be better for different programs; see section 13 for the
   specific requirements.
   
-  You should also get your employer (if you work as a programmer) or school,
+    You should also get your employer (if you work as a programmer) or school,
   if any, to sign a "copyright disclaimer" for the program, if necessary.
   For more information on this, and how to apply and follow the GNU AGPL, see
-  <http://www.gnu.org/licenses/>.
+  <https://www.gnu.org/licenses/>.
   
   '''
 # ---
 # name: test_license[Apache-2.0]
   '''
-  Apache License
-  Version 2.0, January 2004
-  http://www.apache.org/licenses/
   
-  TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+                                   Apache License
+                             Version 2.0, January 2004
+                          http://www.apache.org/licenses/
   
-  1. Definitions.
+     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
   
-  "License" shall mean the terms and conditions for use, reproduction,
-  and distribution as defined by Sections 1 through 9 of this document.
+     1. Definitions.
   
-  "Licensor" shall mean the copyright owner or entity authorized by
-  the copyright owner that is granting the License.
+        "License" shall mean the terms and conditions for use, reproduction,
+        and distribution as defined by Sections 1 through 9 of this document.
   
-  "Legal Entity" shall mean the union of the acting entity and all
-  other entities that control, are controlled by, or are under common
-  control with that entity. For the purposes of this definition,
-  "control" means (i) the power, direct or indirect, to cause the
-  direction or management of such entity, whether by contract or
-  otherwise, or (ii) ownership of fifty percent (50%) or more of the
-  outstanding shares, or (iii) beneficial ownership of such entity.
+        "Licensor" shall mean the copyright owner or entity authorized by
+        the copyright owner that is granting the License.
   
-  "You" (or "Your") shall mean an individual or Legal Entity
-  exercising permissions granted by this License.
+        "Legal Entity" shall mean the union of the acting entity and all
+        other entities that control, are controlled by, or are under common
+        control with that entity. For the purposes of this definition,
+        "control" means (i) the power, direct or indirect, to cause the
+        direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        outstanding shares, or (iii) beneficial ownership of such entity.
   
-  "Source" form shall mean the preferred form for making modifications,
-  including but not limited to software source code, documentation
-  source, and configuration files.
+        "You" (or "Your") shall mean an individual or Legal Entity
+        exercising permissions granted by this License.
   
-  "Object" form shall mean any form resulting from mechanical
-  transformation or translation of a Source form, including but
-  not limited to compiled object code, generated documentation,
-  and conversions to other media types.
+        "Source" form shall mean the preferred form for making modifications,
+        including but not limited to software source code, documentation
+        source, and configuration files.
   
-  "Work" shall mean the work of authorship, whether in Source or
-  Object form, made available under the License, as indicated by a
-  copyright notice that is included in or attached to the work
-  (an example is provided in the Appendix below).
+        "Object" form shall mean any form resulting from mechanical
+        transformation or translation of a Source form, including but
+        not limited to compiled object code, generated documentation,
+        and conversions to other media types.
   
-  "Derivative Works" shall mean any work, whether in Source or Object
-  form, that is based on (or derived from) the Work and for which the
-  editorial revisions, annotations, elaborations, or other modifications
-  represent, as a whole, an original work of authorship. For the purposes
-  of this License, Derivative Works shall not include works that remain
-  separable from, or merely link (or bind by name) to the interfaces of,
-  the Work and Derivative Works thereof.
+        "Work" shall mean the work of authorship, whether in Source or
+        Object form, made available under the License, as indicated by a
+        copyright notice that is included in or attached to the work
+        (an example is provided in the Appendix below).
   
-  "Contribution" shall mean any work of authorship, including
-  the original version of the Work and any modifications or additions
-  to that Work or Derivative Works thereof, that is intentionally
-  submitted to Licensor for inclusion in the Work by the copyright owner
-  or by an individual or Legal Entity authorized to submit on behalf of
-  the copyright owner. For the purposes of this definition, "submitted"
-  means any form of electronic, verbal, or written communication sent
-  to the Licensor or its representatives, including but not limited to
-  communication on electronic mailing lists, source code control systems,
-  and issue tracking systems that are managed by, or on behalf of, the
-  Licensor for the purpose of discussing and improving the Work, but
-  excluding communication that is conspicuously marked or otherwise
-  designated in writing by the copyright owner as "Not a Contribution."
+        "Derivative Works" shall mean any work, whether in Source or Object
+        form, that is based on (or derived from) the Work and for which the
+        editorial revisions, annotations, elaborations, or other modifications
+        represent, as a whole, an original work of authorship. For the purposes
+        of this License, Derivative Works shall not include works that remain
+        separable from, or merely link (or bind by name) to the interfaces of,
+        the Work and Derivative Works thereof.
   
-  "Contributor" shall mean Licensor and any individual or Legal Entity
-  on behalf of whom a Contribution has been received by Licensor and
-  subsequently incorporated within the Work.
+        "Contribution" shall mean any work of authorship, including
+        the original version of the Work and any modifications or additions
+        to that Work or Derivative Works thereof, that is intentionally
+        submitted to Licensor for inclusion in the Work by the copyright owner
+        or by an individual or Legal Entity authorized to submit on behalf of
+        the copyright owner. For the purposes of this definition, "submitted"
+        means any form of electronic, verbal, or written communication sent
+        to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems,
+        and issue tracking systems that are managed by, or on behalf of, the
+        Licensor for the purpose of discussing and improving the Work, but
+        excluding communication that is conspicuously marked or otherwise
+        designated in writing by the copyright owner as "Not a Contribution."
   
-  2. Grant of Copyright License. Subject to the terms and conditions of
-  this License, each Contributor hereby grants to You a perpetual,
-  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-  copyright license to reproduce, prepare Derivative Works of,
-  publicly display, publicly perform, sublicense, and distribute the
-  Work and such Derivative Works in Source or Object form.
+        "Contributor" shall mean Licensor and any individual or Legal Entity
+        on behalf of whom a Contribution has been received by Licensor and
+        subsequently incorporated within the Work.
   
-  3. Grant of Patent License. Subject to the terms and conditions of
-  this License, each Contributor hereby grants to You a perpetual,
-  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-  (except as stated in this section) patent license to make, have made,
-  use, offer to sell, sell, import, and otherwise transfer the Work,
-  where such license applies only to those patent claims licensable
-  by such Contributor that are necessarily infringed by their
-  Contribution(s) alone or by combination of their Contribution(s)
-  with the Work to which such Contribution(s) was submitted. If You
-  institute patent litigation against any entity (including a
-  cross-claim or counterclaim in a lawsuit) alleging that the Work
-  or a Contribution incorporated within the Work constitutes direct
-  or contributory patent infringement, then any patent licenses
-  granted to You under this License for that Work shall terminate
-  as of the date such litigation is filed.
+     2. Grant of Copyright License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        copyright license to reproduce, prepare Derivative Works of,
+        publicly display, publicly perform, sublicense, and distribute the
+        Work and such Derivative Works in Source or Object form.
   
-  4. Redistribution. You may reproduce and distribute copies of the
-  Work or Derivative Works thereof in any medium, with or without
-  modifications, and in Source or Object form, provided that You
-  meet the following conditions:
+     3. Grant of Patent License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        (except as stated in this section) patent license to make, have made,
+        use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable
+        by such Contributor that are necessarily infringed by their
+        Contribution(s) alone or by combination of their Contribution(s)
+        with the Work to which such Contribution(s) was submitted. If You
+        institute patent litigation against any entity (including a
+        cross-claim or counterclaim in a lawsuit) alleging that the Work
+        or a Contribution incorporated within the Work constitutes direct
+        or contributory patent infringement, then any patent licenses
+        granted to You under this License for that Work shall terminate
+        as of the date such litigation is filed.
   
-  (a) You must give any other recipients of the Work or
-  Derivative Works a copy of this License; and
+     4. Redistribution. You may reproduce and distribute copies of the
+        Work or Derivative Works thereof in any medium, with or without
+        modifications, and in Source or Object form, provided that You
+        meet the following conditions:
   
-  (b) You must cause any modified files to carry prominent notices
-  stating that You changed the files; and
+        (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
   
-  (c) You must retain, in the Source form of any Derivative Works
-  that You distribute, all copyright, patent, trademark, and
-  attribution notices from the Source form of the Work,
-  excluding those notices that do not pertain to any part of
-  the Derivative Works; and
+        (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
   
-  (d) If the Work includes a "NOTICE" text file as part of its
-  distribution, then any Derivative Works that You distribute must
-  include a readable copy of the attribution notices contained
-  within such NOTICE file, excluding those notices that do not
-  pertain to any part of the Derivative Works, in at least one
-  of the following places: within a NOTICE text file distributed
-  as part of the Derivative Works; within the Source form or
-  documentation, if provided along with the Derivative Works; or,
-  within a display generated by the Derivative Works, if and
-  wherever such third-party notices normally appear. The contents
-  of the NOTICE file are for informational purposes only and
-  do not modify the License. You may add Your own attribution
-  notices within Derivative Works that You distribute, alongside
-  or as an addendum to the NOTICE text from the Work, provided
-  that such additional attribution notices cannot be construed
-  as modifying the License.
+        (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
   
-  You may add Your own copyright statement to Your modifications and
-  may provide additional or different license terms and conditions
-  for use, reproduction, or distribution of Your modifications, or
-  for any such Derivative Works as a whole, provided Your use,
-  reproduction, and distribution of the Work otherwise complies with
-  the conditions stated in this License.
+        (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
   
-  5. Submission of Contributions. Unless You explicitly state otherwise,
-  any Contribution intentionally submitted for inclusion in the Work
-  by You to the Licensor shall be under the terms and conditions of
-  this License, without any additional terms or conditions.
-  Notwithstanding the above, nothing herein shall supersede or modify
-  the terms of any separate license agreement you may have executed
-  with Licensor regarding such Contributions.
+        You may add Your own copyright statement to Your modifications and
+        may provide additional or different license terms and conditions
+        for use, reproduction, or distribution of Your modifications, or
+        for any such Derivative Works as a whole, provided Your use,
+        reproduction, and distribution of the Work otherwise complies with
+        the conditions stated in this License.
   
-  6. Trademarks. This License does not grant permission to use the trade
-  names, trademarks, service marks, or product names of the Licensor,
-  except as required for reasonable and customary use in describing the
-  origin of the Work and reproducing the content of the NOTICE file.
+     5. Submission of Contributions. Unless You explicitly state otherwise,
+        any Contribution intentionally submitted for inclusion in the Work
+        by You to the Licensor shall be under the terms and conditions of
+        this License, without any additional terms or conditions.
+        Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed
+        with Licensor regarding such Contributions.
   
-  7. Disclaimer of Warranty. Unless required by applicable law or
-  agreed to in writing, Licensor provides the Work (and each
-  Contributor provides its Contributions) on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-  implied, including, without limitation, any warranties or conditions
-  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-  PARTICULAR PURPOSE. You are solely responsible for determining the
-  appropriateness of using or redistributing the Work and assume any
-  risks associated with Your exercise of permissions under this License.
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor,
+        except as required for reasonable and customary use in describing the
+        origin of the Work and reproducing the content of the NOTICE file.
   
-  8. Limitation of Liability. In no event and under no legal theory,
-  whether in tort (including negligence), contract, or otherwise,
-  unless required by applicable law (such as deliberate and grossly
-  negligent acts) or agreed to in writing, shall any Contributor be
-  liable to You for damages, including any direct, indirect, special,
-  incidental, or consequential damages of any character arising as a
-  result of this License or out of the use or inability to use the
-  Work (including but not limited to damages for loss of goodwill,
-  work stoppage, computer failure or malfunction, or any and all
-  other commercial damages or losses), even if such Contributor
-  has been advised of the possibility of such damages.
+     7. Disclaimer of Warranty. Unless required by applicable law or
+        agreed to in writing, Licensor provides the Work (and each
+        Contributor provides its Contributions) on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied, including, without limitation, any warranties or conditions
+        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        PARTICULAR PURPOSE. You are solely responsible for determining the
+        appropriateness of using or redistributing the Work and assume any
+        risks associated with Your exercise of permissions under this License.
   
-  9. Accepting Warranty or Additional Liability. While redistributing
-  the Work or Derivative Works thereof, You may choose to offer,
-  and charge a fee for, acceptance of support, warranty, indemnity,
-  or other liability obligations and/or rights consistent with this
-  License. However, in accepting such obligations, You may act only
-  on Your own behalf and on Your sole responsibility, not on behalf
-  of any other Contributor, and only if You agree to indemnify,
-  defend, and hold each Contributor harmless for any liability
-  incurred by, or claims asserted against, such Contributor by reason
-  of your accepting any such warranty or additional liability.
+     8. Limitation of Liability. In no event and under no legal theory,
+        whether in tort (including negligence), contract, or otherwise,
+        unless required by applicable law (such as deliberate and grossly
+        negligent acts) or agreed to in writing, shall any Contributor be
+        liable to You for damages, including any direct, indirect, special,
+        incidental, or consequential damages of any character arising as a
+        result of this License or out of the use or inability to use the
+        Work (including but not limited to damages for loss of goodwill,
+        work stoppage, computer failure or malfunction, or any and all
+        other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.
   
-  END OF TERMS AND CONDITIONS
+     9. Accepting Warranty or Additional Liability. While redistributing
+        the Work or Derivative Works thereof, You may choose to offer,
+        and charge a fee for, acceptance of support, warranty, indemnity,
+        or other liability obligations and/or rights consistent with this
+        License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf
+        of any other Contributor, and only if You agree to indemnify,
+        defend, and hold each Contributor harmless for any liability
+        incurred by, or claims asserted against, such Contributor by reason
+        of your accepting any such warranty or additional liability.
   
-  APPENDIX: How to apply the Apache License to your work.
+     END OF TERMS AND CONDITIONS
   
-  To apply the Apache License to your work, attach the following
-  boilerplate notice, with the fields enclosed by brackets "[]"
-  replaced with your own identifying information. (Don't include
-  the brackets!)  The text should be enclosed in the appropriate
-  comment syntax for the file format. We also recommend that a
-  file or class name and description of purpose be included on the
-  same "printed page" as the copyright notice for easier
-  identification within third-party archives.
+     APPENDIX: How to apply the Apache License to your work.
   
-  Copyright [yyyy] [name of copyright owner]
+        To apply the Apache License to your work, attach the following
+        boilerplate notice, with the fields enclosed by brackets "[]"
+        replaced with your own identifying information. (Don't include
+        the brackets!)  The text should be enclosed in the appropriate
+        comment syntax for the file format. We also recommend that a
+        file or class name and description of purpose be included on the
+        same "printed page" as the copyright notice for easier
+        identification within third-party archives.
   
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
+     Copyright [yyyy] [name of copyright owner]
   
-  http://www.apache.org/licenses/LICENSE-2.0
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
   
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+         http://www.apache.org/licenses/LICENSE-2.0
+  
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
   
   '''
 # ---
@@ -942,7 +943,7 @@
        material not subject to the license. This includes other CC-
        licensed material, or material used under an exception or
        limitation to copyright. More considerations for licensors:
-  	wiki.creativecommons.org/Considerations_for_licensors
+      wiki.creativecommons.org/Considerations_for_licensors
   
        Considerations for the public: By using one of our public
        licenses, a licensor grants the public permission to use the
@@ -957,9 +958,9 @@
        rights in the material. A licensor may make special requests,
        such as asking that all changes be marked or described.
        Although not required by our licenses, you are encouraged to
-       respect those requests where reasonable. More_considerations
+       respect those requests where reasonable. More considerations
        for the public:
-  	wiki.creativecommons.org/Considerations_for_licensees
+      wiki.creativecommons.org/Considerations_for_licensees
   
   =======================================================================
   
@@ -1342,7 +1343,7 @@
        material not subject to the license. This includes other CC-
        licensed material, or material used under an exception or
        limitation to copyright. More considerations for licensors:
-  	wiki.creativecommons.org/Considerations_for_licensors
+      wiki.creativecommons.org/Considerations_for_licensors
   
        Considerations for the public: By using one of our public
        licenses, a licensor grants the public permission to use the
@@ -1357,9 +1358,9 @@
        rights in the material. A licensor may make special requests,
        such as asking that all changes be marked or described.
        Although not required by our licenses, you are encouraged to
-       respect those requests where reasonable. More_considerations
+       respect those requests where reasonable. More considerations
        for the public:
-  	wiki.creativecommons.org/Considerations_for_licensees
+      wiki.creativecommons.org/Considerations_for_licensees
   
   =======================================================================
   
@@ -1612,8 +1613,8 @@
        contents in a database in which You have Sui Generis Database
        Rights, then the database in which You have Sui Generis Database
        Rights (but not its individual contents) is Adapted Material,
-  
        including for purposes of Section 3(b); and
+  
     c. You must comply with the conditions in Section 3(a) if You Share
        all or a substantial portion of the contents of the database.
   
@@ -1739,140 +1740,145 @@
 # ---
 # name: test_license[CC0-1.0]
   '''
+  Creative Commons Legal Code
+  
   CC0 1.0 Universal
+  
+      CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+      LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+      ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+      INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+      REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+      PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+      THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+      HEREUNDER.
   
   Statement of Purpose
   
   The laws of most jurisdictions throughout the world automatically confer
-  exclusive Copyright and Related Rights (defined below) upon the creator and
-  subsequent owner(s) (each and all, an "owner") of an original work of
+  exclusive Copyright and Related Rights (defined below) upon the creator
+  and subsequent owner(s) (each and all, an "owner") of an original work of
   authorship and/or a database (each, a "Work").
   
-  Certain owners wish to permanently relinquish those rights to a Work for the
-  purpose of contributing to a commons of creative, cultural and scientific
-  works ("Commons") that the public can reliably and without fear of later
-  claims of infringement build upon, modify, incorporate in other works, reuse
-  and redistribute as freely as possible in any form whatsoever and for any
-  purposes, including without limitation commercial purposes. These owners may
-  contribute to the Commons to promote the ideal of a free culture and the
-  further production of creative, cultural and scientific works, or to gain
-  reputation or greater distribution for their Work in part through the use and
-  efforts of others.
+  Certain owners wish to permanently relinquish those rights to a Work for
+  the purpose of contributing to a commons of creative, cultural and
+  scientific works ("Commons") that the public can reliably and without fear
+  of later claims of infringement build upon, modify, incorporate in other
+  works, reuse and redistribute as freely as possible in any form whatsoever
+  and for any purposes, including without limitation commercial purposes.
+  These owners may contribute to the Commons to promote the ideal of a free
+  culture and the further production of creative, cultural and scientific
+  works, or to gain reputation or greater distribution for their Work in
+  part through the use and efforts of others.
   
-  For these and/or other purposes and motivations, and without any expectation
-  of additional consideration or compensation, the person associating CC0 with a
-  Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
-  and Related Rights in the Work, voluntarily elects to apply CC0 to the Work
-  and publicly distribute the Work under its terms, with knowledge of his or her
-  Copyright and Related Rights in the Work and the meaning and intended legal
-  effect of CC0 on those rights.
+  For these and/or other purposes and motivations, and without any
+  expectation of additional consideration or compensation, the person
+  associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+  is an owner of Copyright and Related Rights in the Work, voluntarily
+  elects to apply CC0 to the Work and publicly distribute the Work under its
+  terms, with knowledge of his or her Copyright and Related Rights in the
+  Work and the meaning and intended legal effect of CC0 on those rights.
   
   1. Copyright and Related Rights. A Work made available under CC0 may be
   protected by copyright and related or neighboring rights ("Copyright and
-  Related Rights"). Copyright and Related Rights include, but are not limited
-  to, the following:
+  Related Rights"). Copyright and Related Rights include, but are not
+  limited to, the following:
   
-    i. the right to reproduce, adapt, distribute, perform, display, communicate,
-    and translate a Work;
+    i. the right to reproduce, adapt, distribute, perform, display,
+       communicate, and translate a Work;
+   ii. moral rights retained by the original author(s) and/or performer(s);
+  iii. publicity and privacy rights pertaining to a person's image or
+       likeness depicted in a Work;
+   iv. rights protecting against unfair competition in regards to a Work,
+       subject to the limitations in paragraph 4(a), below;
+    v. rights protecting the extraction, dissemination, use and reuse of data
+       in a Work;
+   vi. database rights (such as those arising under Directive 96/9/EC of the
+       European Parliament and of the Council of 11 March 1996 on the legal
+       protection of databases, and under any national implementation
+       thereof, including any amended or successor version of such
+       directive); and
+  vii. other similar, equivalent or corresponding rights throughout the
+       world based on applicable law or treaty, and any national
+       implementations thereof.
   
-    ii. moral rights retained by the original author(s) and/or performer(s);
+  2. Waiver. To the greatest extent permitted by, but not in contravention
+  of, applicable law, Affirmer hereby overtly, fully, permanently,
+  irrevocably and unconditionally waives, abandons, and surrenders all of
+  Affirmer's Copyright and Related Rights and associated claims and causes
+  of action, whether now known or unknown (including existing as well as
+  future claims and causes of action), in the Work (i) in all territories
+  worldwide, (ii) for the maximum duration provided by applicable law or
+  treaty (including future time extensions), (iii) in any current or future
+  medium and for any number of copies, and (iv) for any purpose whatsoever,
+  including without limitation commercial, advertising or promotional
+  purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+  member of the public at large and to the detriment of Affirmer's heirs and
+  successors, fully intending that such Waiver shall not be subject to
+  revocation, rescission, cancellation, termination, or any other legal or
+  equitable action to disrupt the quiet enjoyment of the Work by the public
+  as contemplated by Affirmer's express Statement of Purpose.
   
-    iii. publicity and privacy rights pertaining to a person's image or likeness
-    depicted in a Work;
-  
-    iv. rights protecting against unfair competition in regards to a Work,
-    subject to the limitations in paragraph 4(a), below;
-  
-    v. rights protecting the extraction, dissemination, use and reuse of data in
-    a Work;
-  
-    vi. database rights (such as those arising under Directive 96/9/EC of the
-    European Parliament and of the Council of 11 March 1996 on the legal
-    protection of databases, and under any national implementation thereof,
-    including any amended or successor version of such directive); and
-  
-    vii. other similar, equivalent or corresponding rights throughout the world
-    based on applicable law or treaty, and any national implementations thereof.
-  
-  2. Waiver. To the greatest extent permitted by, but not in contravention of,
-  applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
-  unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
-  and Related Rights and associated claims and causes of action, whether now
-  known or unknown (including existing as well as future claims and causes of
-  action), in the Work (i) in all territories worldwide, (ii) for the maximum
-  duration provided by applicable law or treaty (including future time
-  extensions), (iii) in any current or future medium and for any number of
-  copies, and (iv) for any purpose whatsoever, including without limitation
-  commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
-  the Waiver for the benefit of each member of the public at large and to the
-  detriment of Affirmer's heirs and successors, fully intending that such Waiver
-  shall not be subject to revocation, rescission, cancellation, termination, or
-  any other legal or equitable action to disrupt the quiet enjoyment of the Work
-  by the public as contemplated by Affirmer's express Statement of Purpose.
-  
-  3. Public License Fallback. Should any part of the Waiver for any reason be
-  judged legally invalid or ineffective under applicable law, then the Waiver
-  shall be preserved to the maximum extent permitted taking into account
-  Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
-  is so judged Affirmer hereby grants to each affected person a royalty-free,
-  non transferable, non sublicensable, non exclusive, irrevocable and
-  unconditional license to exercise Affirmer's Copyright and Related Rights in
-  the Work (i) in all territories worldwide, (ii) for the maximum duration
-  provided by applicable law or treaty (including future time extensions), (iii)
-  in any current or future medium and for any number of copies, and (iv) for any
-  purpose whatsoever, including without limitation commercial, advertising or
-  promotional purposes (the "License"). The License shall be deemed effective as
-  of the date CC0 was applied by Affirmer to the Work. Should any part of the
-  License for any reason be judged legally invalid or ineffective under
-  applicable law, such partial invalidity or ineffectiveness shall not
-  invalidate the remainder of the License, and in such case Affirmer hereby
-  affirms that he or she will not (i) exercise any of his or her remaining
-  Copyright and Related Rights in the Work or (ii) assert any associated claims
-  and causes of action with respect to the Work, in either case contrary to
-  Affirmer's express Statement of Purpose.
+  3. Public License Fallback. Should any part of the Waiver for any reason
+  be judged legally invalid or ineffective under applicable law, then the
+  Waiver shall be preserved to the maximum extent permitted taking into
+  account Affirmer's express Statement of Purpose. In addition, to the
+  extent the Waiver is so judged Affirmer hereby grants to each affected
+  person a royalty-free, non transferable, non sublicensable, non exclusive,
+  irrevocable and unconditional license to exercise Affirmer's Copyright and
+  Related Rights in the Work (i) in all territories worldwide, (ii) for the
+  maximum duration provided by applicable law or treaty (including future
+  time extensions), (iii) in any current or future medium and for any number
+  of copies, and (iv) for any purpose whatsoever, including without
+  limitation commercial, advertising or promotional purposes (the
+  "License"). The License shall be deemed effective as of the date CC0 was
+  applied by Affirmer to the Work. Should any part of the License for any
+  reason be judged legally invalid or ineffective under applicable law, such
+  partial invalidity or ineffectiveness shall not invalidate the remainder
+  of the License, and in such case Affirmer hereby affirms that he or she
+  will not (i) exercise any of his or her remaining Copyright and Related
+  Rights in the Work or (ii) assert any associated claims and causes of
+  action with respect to the Work, in either case contrary to Affirmer's
+  express Statement of Purpose.
   
   4. Limitations and Disclaimers.
   
-    a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
-  
-    b. Affirmer offers the Work as-is and makes no representations or warranties
-    of any kind concerning the Work, express, implied, statutory or otherwise,
-    including without limitation warranties of title, merchantability, fitness
-    for a particular purpose, non infringement, or the absence of latent or
-    other defects, accuracy, or the present or absence of errors, whether or not
-    discoverable, all to the greatest extent permissible under applicable law.
-  
-    c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without limitation
-    any person's Copyright and Related Rights in the Work. Further, Affirmer
-    disclaims responsibility for obtaining any necessary consents, permissions
-    or other rights required for any use of the Work.
-  
-    d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to this
-    CC0 or use of the Work.
-  
-  For more information, please see
-  <http://creativecommons.org/publicdomain/zero/1.0/>
+   a. No trademark or patent rights held by Affirmer are waived, abandoned,
+      surrendered, licensed or otherwise affected by this document.
+   b. Affirmer offers the Work as-is and makes no representations or
+      warranties of any kind concerning the Work, express, implied,
+      statutory or otherwise, including without limitation warranties of
+      title, merchantability, fitness for a particular purpose, non
+      infringement, or the absence of latent or other defects, accuracy, or
+      the present or absence of errors, whether or not discoverable, all to
+      the greatest extent permissible under applicable law.
+   c. Affirmer disclaims responsibility for clearing rights of other persons
+      that may apply to the Work or any use thereof, including without
+      limitation any person's Copyright and Related Rights in the Work.
+      Further, Affirmer disclaims responsibility for obtaining any necessary
+      consents, permissions or other rights required for any use of the
+      Work.
+   d. Affirmer understands and acknowledges that Creative Commons is not a
+      party to this document and has no duty or obligation with respect to
+      this CC0 or use of the Work.
   
   '''
 # ---
 # name: test_license[GPL-3.0]
   '''
-  GNU GENERAL PUBLIC LICENSE
-     Version 3, 29 June 2007
+                      GNU GENERAL PUBLIC LICENSE
+                         Version 3, 29 June 2007
   
-  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-  Everyone is permitted to copy and distribute verbatim copies
-  of this license document, but changing it is not allowed.
+   Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+   Everyone is permitted to copy and distribute verbatim copies
+   of this license document, but changing it is not allowed.
   
-          Preamble
+                              Preamble
   
-  The GNU General Public License is a free, copyleft license for
+    The GNU General Public License is a free, copyleft license for
   software and other kinds of works.
   
-  The licenses for most software and other practical works are designed
+    The licenses for most software and other practical works are designed
   to take away your freedom to share and change the works.  By contrast,
   the GNU General Public License is intended to guarantee your freedom to
   share and change all versions of a program--to make sure it remains free
@@ -1881,35 +1887,35 @@
   any other work released this way by its authors.  You can apply it to
   your programs, too.
   
-  When we speak of free software, we are referring to freedom, not
+    When we speak of free software, we are referring to freedom, not
   price.  Our General Public Licenses are designed to make sure that you
   have the freedom to distribute copies of free software (and charge for
   them if you wish), that you receive source code or can get it if you
   want it, that you can change the software or use pieces of it in new
   free programs, and that you know you can do these things.
   
-  To protect your rights, we need to prevent others from denying you
+    To protect your rights, we need to prevent others from denying you
   these rights or asking you to surrender the rights.  Therefore, you have
   certain responsibilities if you distribute copies of the software, or if
   you modify it: responsibilities to respect the freedom of others.
   
-  For example, if you distribute copies of such a program, whether
+    For example, if you distribute copies of such a program, whether
   gratis or for a fee, you must pass on to the recipients the same
   freedoms that you received.  You must make sure that they, too, receive
   or can get the source code.  And you must show them these terms so they
   know their rights.
   
-  Developers that use the GNU GPL protect your rights with two steps:
+    Developers that use the GNU GPL protect your rights with two steps:
   (1) assert copyright on the software, and (2) offer you this License
   giving you legal permission to copy, distribute and/or modify it.
   
-  For the developers' and authors' protection, the GPL clearly explains
+    For the developers' and authors' protection, the GPL clearly explains
   that there is no warranty for this free software.  For both users' and
   authors' sake, the GPL requires that modified versions be marked as
   changed, so that their problems will not be attributed erroneously to
   authors of previous versions.
   
-  Some devices are designed to deny users access to install or run
+    Some devices are designed to deny users access to install or run
   modified versions of the software inside them, although the manufacturer
   can do so.  This is fundamentally incompatible with the aim of
   protecting users' freedom to change the software.  The systematic
@@ -1920,49 +1926,49 @@
   stand ready to extend this provision to those domains in future versions
   of the GPL, as needed to protect the freedom of users.
   
-  Finally, every program is threatened constantly by software patents.
+    Finally, every program is threatened constantly by software patents.
   States should not allow patents to restrict development and use of
   software on general-purpose computers, but in those that do, we wish to
   avoid the special danger that patents applied to a free program could
   make it effectively proprietary.  To prevent this, the GPL assures that
   patents cannot be used to render the program non-free.
   
-  The precise terms and conditions for copying, distribution and
+    The precise terms and conditions for copying, distribution and
   modification follow.
   
-     TERMS AND CONDITIONS
+                         TERMS AND CONDITIONS
   
-  0. Definitions.
+    0. Definitions.
   
-  "This License" refers to version 3 of the GNU General Public License.
+    "This License" refers to version 3 of the GNU General Public License.
   
-  "Copyright" also means copyright-like laws that apply to other kinds of
+    "Copyright" also means copyright-like laws that apply to other kinds of
   works, such as semiconductor masks.
   
-  "The Program" refers to any copyrightable work licensed under this
+    "The Program" refers to any copyrightable work licensed under this
   License.  Each licensee is addressed as "you".  "Licensees" and
   "recipients" may be individuals or organizations.
   
-  To "modify" a work means to copy from or adapt all or part of the work
+    To "modify" a work means to copy from or adapt all or part of the work
   in a fashion requiring copyright permission, other than the making of an
   exact copy.  The resulting work is called a "modified version" of the
   earlier work or a work "based on" the earlier work.
   
-  A "covered work" means either the unmodified Program or a work based
+    A "covered work" means either the unmodified Program or a work based
   on the Program.
   
-  To "propagate" a work means to do anything with it that, without
+    To "propagate" a work means to do anything with it that, without
   permission, would make you directly or secondarily liable for
   infringement under applicable copyright law, except executing it on a
   computer or modifying a private copy.  Propagation includes copying,
   distribution (with or without modification), making available to the
   public, and in some countries other activities as well.
   
-  To "convey" a work means any kind of propagation that enables other
+    To "convey" a work means any kind of propagation that enables other
   parties to make or receive copies.  Mere interaction with a user through
   a computer network, with no transfer of a copy, is not conveying.
   
-  An interactive user interface displays "Appropriate Legal Notices"
+    An interactive user interface displays "Appropriate Legal Notices"
   to the extent that it includes a convenient and prominently visible
   feature that (1) displays an appropriate copyright notice, and (2)
   tells the user that there is no warranty for the work (except to the
@@ -1971,18 +1977,18 @@
   the interface presents a list of user commands or options, such as a
   menu, a prominent item in the list meets this criterion.
   
-  1. Source Code.
+    1. Source Code.
   
-  The "source code" for a work means the preferred form of the work
+    The "source code" for a work means the preferred form of the work
   for making modifications to it.  "Object code" means any non-source
   form of a work.
   
-  A "Standard Interface" means an interface that either is an official
+    A "Standard Interface" means an interface that either is an official
   standard defined by a recognized standards body, or, in the case of
   interfaces specified for a particular programming language, one that
   is widely used among developers working in that language.
   
-  The "System Libraries" of an executable work include anything, other
+    The "System Libraries" of an executable work include anything, other
   than the work as a whole, that (a) is included in the normal form of
   packaging a Major Component, but which is not part of that Major
   Component, and (b) serves only to enable use of the work with that
@@ -1993,7 +1999,7 @@
   (if any) on which the executable work runs, or a compiler used to
   produce the work, or an object code interpreter used to run it.
   
-  The "Corresponding Source" for a work in object code form means all
+    The "Corresponding Source" for a work in object code form means all
   the source code needed to generate, install, and (for an executable
   work) run the object code and to modify the work, including scripts to
   control those activities.  However, it does not include the work's
@@ -2006,16 +2012,16 @@
   such as by intimate data communication or control flow between those
   subprograms and other parts of the work.
   
-  The Corresponding Source need not include anything that users
+    The Corresponding Source need not include anything that users
   can regenerate automatically from other parts of the Corresponding
   Source.
   
-  The Corresponding Source for a work in source code form is that
+    The Corresponding Source for a work in source code form is that
   same work.
   
-  2. Basic Permissions.
+    2. Basic Permissions.
   
-  All rights granted under this License are granted for the term of
+    All rights granted under this License are granted for the term of
   copyright on the Program, and are irrevocable provided the stated
   conditions are met.  This License explicitly affirms your unlimited
   permission to run the unmodified Program.  The output from running a
@@ -2023,7 +2029,7 @@
   content, constitutes a covered work.  This License acknowledges your
   rights of fair use or other equivalent, as provided by copyright law.
   
-  You may make, run and propagate covered works that you do not
+    You may make, run and propagate covered works that you do not
   convey, without conditions so long as your license otherwise remains
   in force.  You may convey covered works to others for the sole purpose
   of having them make modifications exclusively for you, or provide you
@@ -2034,19 +2040,19 @@
   and control, on terms that prohibit them from making any copies of
   your copyrighted material outside their relationship with you.
   
-  Conveying under any other circumstances is permitted solely under
+    Conveying under any other circumstances is permitted solely under
   the conditions stated below.  Sublicensing is not allowed; section 10
   makes it unnecessary.
   
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+    3. Protecting Users' Legal Rights From Anti-Circumvention Law.
   
-  No covered work shall be deemed part of an effective technological
+    No covered work shall be deemed part of an effective technological
   measure under any applicable law fulfilling obligations under article
   11 of the WIPO copyright treaty adopted on 20 December 1996, or
   similar laws prohibiting or restricting circumvention of such
   measures.
   
-  When you convey a covered work, you waive any legal power to forbid
+    When you convey a covered work, you waive any legal power to forbid
   circumvention of technological measures to the extent such circumvention
   is effected by exercising rights under this License with respect to
   the covered work, and you disclaim any intention to limit operation or
@@ -2054,9 +2060,9 @@
   users, your or third parties' legal rights to forbid circumvention of
   technological measures.
   
-  4. Conveying Verbatim Copies.
+    4. Conveying Verbatim Copies.
   
-  You may convey verbatim copies of the Program's source code as you
+    You may convey verbatim copies of the Program's source code as you
   receive it, in any medium, provided that you conspicuously and
   appropriately publish on each copy an appropriate copyright notice;
   keep intact all notices stating that this License and any
@@ -2064,37 +2070,37 @@
   keep intact all notices of the absence of any warranty; and give all
   recipients a copy of this License along with the Program.
   
-  You may charge any price or no price for each copy that you convey,
+    You may charge any price or no price for each copy that you convey,
   and you may offer support or warranty protection for a fee.
   
-  5. Conveying Modified Source Versions.
+    5. Conveying Modified Source Versions.
   
-  You may convey a work based on the Program, or the modifications to
+    You may convey a work based on the Program, or the modifications to
   produce it from the Program, in the form of source code under the
   terms of section 4, provided that you also meet all of these conditions:
   
-  a) The work must carry prominent notices stating that you modified
-  it, and giving a relevant date.
+      a) The work must carry prominent notices stating that you modified
+      it, and giving a relevant date.
   
-  b) The work must carry prominent notices stating that it is
-  released under this License and any conditions added under section
-  7.  This requirement modifies the requirement in section 4 to
-  "keep intact all notices".
+      b) The work must carry prominent notices stating that it is
+      released under this License and any conditions added under section
+      7.  This requirement modifies the requirement in section 4 to
+      "keep intact all notices".
   
-  c) You must license the entire work, as a whole, under this
-  License to anyone who comes into possession of a copy.  This
-  License will therefore apply, along with any applicable section 7
-  additional terms, to the whole of the work, and all its parts,
-  regardless of how they are packaged.  This License gives no
-  permission to license the work in any other way, but it does not
-  invalidate such permission if you have separately received it.
+      c) You must license the entire work, as a whole, under this
+      License to anyone who comes into possession of a copy.  This
+      License will therefore apply, along with any applicable section 7
+      additional terms, to the whole of the work, and all its parts,
+      regardless of how they are packaged.  This License gives no
+      permission to license the work in any other way, but it does not
+      invalidate such permission if you have separately received it.
   
-  d) If the work has interactive user interfaces, each must display
-  Appropriate Legal Notices; however, if the Program has interactive
-  interfaces that do not display Appropriate Legal Notices, your
-  work need not make them do so.
+      d) If the work has interactive user interfaces, each must display
+      Appropriate Legal Notices; however, if the Program has interactive
+      interfaces that do not display Appropriate Legal Notices, your
+      work need not make them do so.
   
-  A compilation of a covered work with other separate and independent
+    A compilation of a covered work with other separate and independent
   works, which are not by their nature extensions of the covered work,
   and which are not combined with it such as to form a larger program,
   in or on a volume of a storage or distribution medium, is called an
@@ -2104,59 +2110,59 @@
   in an aggregate does not cause this License to apply to the other
   parts of the aggregate.
   
-  6. Conveying Non-Source Forms.
+    6. Conveying Non-Source Forms.
   
-  You may convey a covered work in object code form under the terms
+    You may convey a covered work in object code form under the terms
   of sections 4 and 5, provided that you also convey the
   machine-readable Corresponding Source under the terms of this License,
   in one of these ways:
   
-  a) Convey the object code in, or embodied in, a physical product
-  (including a physical distribution medium), accompanied by the
-  Corresponding Source fixed on a durable physical medium
-  customarily used for software interchange.
+      a) Convey the object code in, or embodied in, a physical product
+      (including a physical distribution medium), accompanied by the
+      Corresponding Source fixed on a durable physical medium
+      customarily used for software interchange.
   
-  b) Convey the object code in, or embodied in, a physical product
-  (including a physical distribution medium), accompanied by a
-  written offer, valid for at least three years and valid for as
-  long as you offer spare parts or customer support for that product
-  model, to give anyone who possesses the object code either (1) a
-  copy of the Corresponding Source for all the software in the
-  product that is covered by this License, on a durable physical
-  medium customarily used for software interchange, for a price no
-  more than your reasonable cost of physically performing this
-  conveying of source, or (2) access to copy the
-  Corresponding Source from a network server at no charge.
+      b) Convey the object code in, or embodied in, a physical product
+      (including a physical distribution medium), accompanied by a
+      written offer, valid for at least three years and valid for as
+      long as you offer spare parts or customer support for that product
+      model, to give anyone who possesses the object code either (1) a
+      copy of the Corresponding Source for all the software in the
+      product that is covered by this License, on a durable physical
+      medium customarily used for software interchange, for a price no
+      more than your reasonable cost of physically performing this
+      conveying of source, or (2) access to copy the
+      Corresponding Source from a network server at no charge.
   
-  c) Convey individual copies of the object code with a copy of the
-  written offer to provide the Corresponding Source.  This
-  alternative is allowed only occasionally and noncommercially, and
-  only if you received the object code with such an offer, in accord
-  with subsection 6b.
+      c) Convey individual copies of the object code with a copy of the
+      written offer to provide the Corresponding Source.  This
+      alternative is allowed only occasionally and noncommercially, and
+      only if you received the object code with such an offer, in accord
+      with subsection 6b.
   
-  d) Convey the object code by offering access from a designated
-  place (gratis or for a charge), and offer equivalent access to the
-  Corresponding Source in the same way through the same place at no
-  further charge.  You need not require recipients to copy the
-  Corresponding Source along with the object code.  If the place to
-  copy the object code is a network server, the Corresponding Source
-  may be on a different server (operated by you or a third party)
-  that supports equivalent copying facilities, provided you maintain
-  clear directions next to the object code saying where to find the
-  Corresponding Source.  Regardless of what server hosts the
-  Corresponding Source, you remain obligated to ensure that it is
-  available for as long as needed to satisfy these requirements.
+      d) Convey the object code by offering access from a designated
+      place (gratis or for a charge), and offer equivalent access to the
+      Corresponding Source in the same way through the same place at no
+      further charge.  You need not require recipients to copy the
+      Corresponding Source along with the object code.  If the place to
+      copy the object code is a network server, the Corresponding Source
+      may be on a different server (operated by you or a third party)
+      that supports equivalent copying facilities, provided you maintain
+      clear directions next to the object code saying where to find the
+      Corresponding Source.  Regardless of what server hosts the
+      Corresponding Source, you remain obligated to ensure that it is
+      available for as long as needed to satisfy these requirements.
   
-  e) Convey the object code using peer-to-peer transmission, provided
-  you inform other peers where the object code and Corresponding
-  Source of the work are being offered to the general public at no
-  charge under subsection 6d.
+      e) Convey the object code using peer-to-peer transmission, provided
+      you inform other peers where the object code and Corresponding
+      Source of the work are being offered to the general public at no
+      charge under subsection 6d.
   
-  A separable portion of the object code, whose source code is excluded
+    A separable portion of the object code, whose source code is excluded
   from the Corresponding Source as a System Library, need not be
   included in conveying the object code work.
   
-  A "User Product" is either (1) a "consumer product", which means any
+    A "User Product" is either (1) a "consumer product", which means any
   tangible personal property which is normally used for personal, family,
   or household purposes, or (2) anything designed or sold for incorporation
   into a dwelling.  In determining whether a product is a consumer product,
@@ -2169,7 +2175,7 @@
   commercial, industrial or non-consumer uses, unless such uses represent
   the only significant mode of use of the product.
   
-  "Installation Information" for a User Product means any methods,
+    "Installation Information" for a User Product means any methods,
   procedures, authorization keys, or other information required to install
   and execute modified versions of a covered work in that User Product from
   a modified version of its Corresponding Source.  The information must
@@ -2177,7 +2183,7 @@
   code is in no case prevented or interfered with solely because
   modification has been made.
   
-  If you convey an object code work under this section in, or with, or
+    If you convey an object code work under this section in, or with, or
   specifically for use in, a User Product, and the conveying occurs as
   part of a transaction in which the right of possession and use of the
   User Product is transferred to the recipient in perpetuity or for a
@@ -2188,7 +2194,7 @@
   modified object code on the User Product (for example, the work has
   been installed in ROM).
   
-  The requirement to provide Installation Information does not include a
+    The requirement to provide Installation Information does not include a
   requirement to continue to provide support service, warranty, or updates
   for a work that has been modified or installed by the recipient, or for
   the User Product in which it has been modified or installed.  Access to a
@@ -2196,15 +2202,15 @@
   adversely affects the operation of the network or violates the rules and
   protocols for communication across the network.
   
-  Corresponding Source conveyed, and Installation Information provided,
+    Corresponding Source conveyed, and Installation Information provided,
   in accord with this section must be in a format that is publicly
   documented (and with an implementation available to the public in
   source code form), and must require no special password or key for
   unpacking, reading or copying.
   
-  7. Additional Terms.
+    7. Additional Terms.
   
-  "Additional permissions" are terms that supplement the terms of this
+    "Additional permissions" are terms that supplement the terms of this
   License by making exceptions from one or more of its conditions.
   Additional permissions that are applicable to the entire Program shall
   be treated as though they were included in this License, to the extent
@@ -2213,41 +2219,41 @@
   under those permissions, but the entire Program remains governed by
   this License without regard to the additional permissions.
   
-  When you convey a copy of a covered work, you may at your option
+    When you convey a copy of a covered work, you may at your option
   remove any additional permissions from that copy, or from any part of
   it.  (Additional permissions may be written to require their own
   removal in certain cases when you modify the work.)  You may place
   additional permissions on material, added by you to a covered work,
   for which you have or can give appropriate copyright permission.
   
-  Notwithstanding any other provision of this License, for material you
+    Notwithstanding any other provision of this License, for material you
   add to a covered work, you may (if authorized by the copyright holders of
   that material) supplement the terms of this License with terms:
   
-  a) Disclaiming warranty or limiting liability differently from the
-  terms of sections 15 and 16 of this License; or
+      a) Disclaiming warranty or limiting liability differently from the
+      terms of sections 15 and 16 of this License; or
   
-  b) Requiring preservation of specified reasonable legal notices or
-  author attributions in that material or in the Appropriate Legal
-  Notices displayed by works containing it; or
+      b) Requiring preservation of specified reasonable legal notices or
+      author attributions in that material or in the Appropriate Legal
+      Notices displayed by works containing it; or
   
-  c) Prohibiting misrepresentation of the origin of that material, or
-  requiring that modified versions of such material be marked in
-  reasonable ways as different from the original version; or
+      c) Prohibiting misrepresentation of the origin of that material, or
+      requiring that modified versions of such material be marked in
+      reasonable ways as different from the original version; or
   
-  d) Limiting the use for publicity purposes of names of licensors or
-  authors of the material; or
+      d) Limiting the use for publicity purposes of names of licensors or
+      authors of the material; or
   
-  e) Declining to grant rights under trademark law for use of some
-  trade names, trademarks, or service marks; or
+      e) Declining to grant rights under trademark law for use of some
+      trade names, trademarks, or service marks; or
   
-  f) Requiring indemnification of licensors and authors of that
-  material by anyone who conveys the material (or modified versions of
-  it) with contractual assumptions of liability to the recipient, for
-  any liability that these contractual assumptions directly impose on
-  those licensors and authors.
+      f) Requiring indemnification of licensors and authors of that
+      material by anyone who conveys the material (or modified versions of
+      it) with contractual assumptions of liability to the recipient, for
+      any liability that these contractual assumptions directly impose on
+      those licensors and authors.
   
-  All other non-permissive additional terms are considered "further
+    All other non-permissive additional terms are considered "further
   restrictions" within the meaning of section 10.  If the Program as you
   received it, or any part of it, contains a notice stating that it is
   governed by this License along with a term that is a further
@@ -2257,46 +2263,46 @@
   of that license document, provided that the further restriction does
   not survive such relicensing or conveying.
   
-  If you add terms to a covered work in accord with this section, you
+    If you add terms to a covered work in accord with this section, you
   must place, in the relevant source files, a statement of the
   additional terms that apply to those files, or a notice indicating
   where to find the applicable terms.
   
-  Additional terms, permissive or non-permissive, may be stated in the
+    Additional terms, permissive or non-permissive, may be stated in the
   form of a separately written license, or stated as exceptions;
   the above requirements apply either way.
   
-  8. Termination.
+    8. Termination.
   
-  You may not propagate or modify a covered work except as expressly
+    You may not propagate or modify a covered work except as expressly
   provided under this License.  Any attempt otherwise to propagate or
   modify it is void, and will automatically terminate your rights under
   this License (including any patent licenses granted under the third
   paragraph of section 11).
   
-  However, if you cease all violation of this License, then your
+    However, if you cease all violation of this License, then your
   license from a particular copyright holder is reinstated (a)
   provisionally, unless and until the copyright holder explicitly and
   finally terminates your license, and (b) permanently, if the copyright
   holder fails to notify you of the violation by some reasonable means
   prior to 60 days after the cessation.
   
-  Moreover, your license from a particular copyright holder is
+    Moreover, your license from a particular copyright holder is
   reinstated permanently if the copyright holder notifies you of the
   violation by some reasonable means, this is the first time you have
   received notice of violation of this License (for any work) from that
   copyright holder, and you cure the violation prior to 30 days after
   your receipt of the notice.
   
-  Termination of your rights under this section does not terminate the
+    Termination of your rights under this section does not terminate the
   licenses of parties who have received copies or rights from you under
   this License.  If your rights have been terminated and not permanently
   reinstated, you do not qualify to receive new licenses for the same
   material under section 10.
   
-  9. Acceptance Not Required for Having Copies.
+    9. Acceptance Not Required for Having Copies.
   
-  You are not required to accept this License in order to receive or
+    You are not required to accept this License in order to receive or
   run a copy of the Program.  Ancillary propagation of a covered work
   occurring solely as a consequence of using peer-to-peer transmission
   to receive a copy likewise does not require acceptance.  However,
@@ -2305,14 +2311,14 @@
   not accept this License.  Therefore, by modifying or propagating a
   covered work, you indicate your acceptance of this License to do so.
   
-  10. Automatic Licensing of Downstream Recipients.
+    10. Automatic Licensing of Downstream Recipients.
   
-  Each time you convey a covered work, the recipient automatically
+    Each time you convey a covered work, the recipient automatically
   receives a license from the original licensors, to run, modify and
   propagate that work, subject to this License.  You are not responsible
   for enforcing compliance by third parties with this License.
   
-  An "entity transaction" is a transaction transferring control of an
+    An "entity transaction" is a transaction transferring control of an
   organization, or substantially all assets of one, or subdividing an
   organization, or merging organizations.  If propagation of a covered
   work results from an entity transaction, each party to that
@@ -2322,7 +2328,7 @@
   Corresponding Source of the work from the predecessor in interest, if
   the predecessor has it or can get it with reasonable efforts.
   
-  You may not impose any further restrictions on the exercise of the
+    You may not impose any further restrictions on the exercise of the
   rights granted or affirmed under this License.  For example, you may
   not impose a license fee, royalty, or other charge for exercise of
   rights granted under this License, and you may not initiate litigation
@@ -2330,13 +2336,13 @@
   any patent claim is infringed by making, using, selling, offering for
   sale, or importing the Program or any portion of it.
   
-  11. Patents.
+    11. Patents.
   
-  A "contributor" is a copyright holder who authorizes use under this
+    A "contributor" is a copyright holder who authorizes use under this
   License of the Program or a work on which the Program is based.  The
   work thus licensed is called the contributor's "contributor version".
   
-  A contributor's "essential patent claims" are all patent claims
+    A contributor's "essential patent claims" are all patent claims
   owned or controlled by the contributor, whether already acquired or
   hereafter acquired, that would be infringed by some manner, permitted
   by this License, of making, using, or selling its contributor version,
@@ -2346,19 +2352,19 @@
   patent sublicenses in a manner consistent with the requirements of
   this License.
   
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
+    Each contributor grants you a non-exclusive, worldwide, royalty-free
   patent license under the contributor's essential patent claims, to
   make, use, sell, offer for sale, import and otherwise run, modify and
   propagate the contents of its contributor version.
   
-  In the following three paragraphs, a "patent license" is any express
+    In the following three paragraphs, a "patent license" is any express
   agreement or commitment, however denominated, not to enforce a patent
   (such as an express permission to practice a patent or covenant not to
   sue for patent infringement).  To "grant" such a patent license to a
   party means to make such an agreement or commitment not to enforce a
   patent against the party.
   
-  If you convey a covered work, knowingly relying on a patent license,
+    If you convey a covered work, knowingly relying on a patent license,
   and the Corresponding Source of the work is not available for anyone
   to copy, free of charge and under the terms of this License, through a
   publicly available network server or other readily accessible means,
@@ -2372,7 +2378,7 @@
   in a country, would infringe one or more identifiable patents in that
   country that you have reason to believe are valid.
   
-  If, pursuant to or in connection with a single transaction or
+    If, pursuant to or in connection with a single transaction or
   arrangement, you convey, or propagate by procuring conveyance of, a
   covered work, and grant a patent license to some of the parties
   receiving the covered work authorizing them to use, propagate, modify
@@ -2380,7 +2386,7 @@
   you grant is automatically extended to all recipients of the covered
   work and works based on it.
   
-  A patent license is "discriminatory" if it does not include within
+    A patent license is "discriminatory" if it does not include within
   the scope of its coverage, prohibits the exercise of, or is
   conditioned on the non-exercise of one or more of the rights that are
   specifically granted under this License.  You may not convey a covered
@@ -2395,13 +2401,13 @@
   contain the covered work, unless you entered into that arrangement,
   or that patent license was granted, prior to 28 March 2007.
   
-  Nothing in this License shall be construed as excluding or limiting
+    Nothing in this License shall be construed as excluding or limiting
   any implied license or other defenses to infringement that may
   otherwise be available to you under applicable patent law.
   
-  12. No Surrender of Others' Freedom.
+    12. No Surrender of Others' Freedom.
   
-  If conditions are imposed on you (whether by court order, agreement or
+    If conditions are imposed on you (whether by court order, agreement or
   otherwise) that contradict the conditions of this License, they do not
   excuse you from the conditions of this License.  If you cannot convey a
   covered work so as to satisfy simultaneously your obligations under this
@@ -2411,9 +2417,9 @@
   the Program, the only way you could satisfy both those terms and this
   License would be to refrain entirely from conveying the Program.
   
-  13. Use with the GNU Affero General Public License.
+    13. Use with the GNU Affero General Public License.
   
-  Notwithstanding any other provision of this License, you have
+    Notwithstanding any other provision of this License, you have
   permission to link or combine any covered work with a work licensed
   under version 3 of the GNU Affero General Public License into a single
   combined work, and to convey the resulting work.  The terms of this
@@ -2422,14 +2428,14 @@
   section 13, concerning interaction through a network will apply to the
   combination as such.
   
-  14. Revised Versions of this License.
+    14. Revised Versions of this License.
   
-  The Free Software Foundation may publish revised and/or new versions of
+    The Free Software Foundation may publish revised and/or new versions of
   the GNU General Public License from time to time.  Such new versions will
   be similar in spirit to the present version, but may differ in detail to
   address new problems or concerns.
   
-  Each version is given a distinguishing version number.  If the
+    Each version is given a distinguishing version number.  If the
   Program specifies that a certain numbered version of the GNU General
   Public License "or any later version" applies to it, you have the
   option of following the terms and conditions either of that numbered
@@ -2438,19 +2444,19 @@
   GNU General Public License, you may choose any version ever published
   by the Free Software Foundation.
   
-  If the Program specifies that a proxy can decide which future
+    If the Program specifies that a proxy can decide which future
   versions of the GNU General Public License can be used, that proxy's
   public statement of acceptance of a version permanently authorizes you
   to choose that version for the Program.
   
-  Later license versions may give you additional or different
+    Later license versions may give you additional or different
   permissions.  However, no additional obligations are imposed on any
   author or copyright holder as a result of your choosing to follow a
   later version.
   
-  15. Disclaimer of Warranty.
+    15. Disclaimer of Warranty.
   
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+    THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
   APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
   HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
   OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
@@ -2459,9 +2465,9 @@
   IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
   ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
   
-  16. Limitation of Liability.
+    16. Limitation of Liability.
   
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+    IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
   WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
   THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
   GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
@@ -2471,69 +2477,69 @@
   EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
   SUCH DAMAGES.
   
-  17. Interpretation of Sections 15 and 16.
+    17. Interpretation of Sections 15 and 16.
   
-  If the disclaimer of warranty and limitation of liability provided
+    If the disclaimer of warranty and limitation of liability provided
   above cannot be given local legal effect according to their terms,
   reviewing courts shall apply local law that most closely approximates
   an absolute waiver of all civil liability in connection with the
   Program, unless a warranty or assumption of liability accompanies a
   copy of the Program in return for a fee.
   
-   END OF TERMS AND CONDITIONS
+                       END OF TERMS AND CONDITIONS
   
-  How to Apply These Terms to Your New Programs
+              How to Apply These Terms to Your New Programs
   
-  If you develop a new program, and you want it to be of the greatest
+    If you develop a new program, and you want it to be of the greatest
   possible use to the public, the best way to achieve this is to make it
   free software which everyone can redistribute and change under these terms.
   
-  To do so, attach the following notices to the program.  It is safest
+    To do so, attach the following notices to the program.  It is safest
   to attach them to the start of each source file to most effectively
   state the exclusion of warranty; and each file should have at least
   the "copyright" line and a pointer to where the full notice is found.
   
-  <one line to give the program's name and a brief idea of what it does.>
-  Copyright (C) <year>  <name of author>
+      <one line to give the program's name and a brief idea of what it does.>
+      Copyright (C) <year>  <name of author>
   
-  This program is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU General Public License as published by
+      the Free Software Foundation, either version 3 of the License, or
+      (at your option) any later version.
   
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU General Public License for more details.
   
-  You should have received a copy of the GNU General Public License
-  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+      You should have received a copy of the GNU General Public License
+      along with this program.  If not, see <https://www.gnu.org/licenses/>.
   
   Also add information on how to contact you by electronic and paper mail.
   
-  If the program does terminal interaction, make it output a short
+    If the program does terminal interaction, make it output a short
   notice like this when it starts in an interactive mode:
   
-  <program>  Copyright (C) <year>  <name of author>
-  This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-  This is free software, and you are welcome to redistribute it
-  under certain conditions; type `show c' for details.
+      <program>  Copyright (C) <year>  <name of author>
+      This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+      This is free software, and you are welcome to redistribute it
+      under certain conditions; type `show c' for details.
   
   The hypothetical commands `show w' and `show c' should show the appropriate
   parts of the General Public License.  Of course, your program's commands
   might be different; for a GUI interface, you would use an "about box".
   
-  You should also get your employer (if you work as a programmer) or school,
+    You should also get your employer (if you work as a programmer) or school,
   if any, to sign a "copyright disclaimer" for the program, if necessary.
   For more information on this, and how to apply and follow the GNU GPL, see
-  <http://www.gnu.org/licenses/>.
+  <https://www.gnu.org/licenses/>.
   
-  The GNU General Public License does not permit incorporating your program
+    The GNU General Public License does not permit incorporating your program
   into proprietary programs.  If your program is a subroutine library, you
   may consider it more useful to permit linking proprietary applications with
   the library.  If this is what you want to do, use the GNU Lesser General
   Public License instead of this License.  But first, please read
-  <http://www.gnu.org/philosophy/why-not-lgpl.html>.
+  <https://www.gnu.org/licenses/why-not-lgpl.html>.
   
   '''
 # ---
@@ -2559,157 +2565,157 @@
 # ---
 # name: test_license[LGPL-3.0]
   '''
-  GNU LESSER GENERAL PUBLIC LICENSE
-      Version 3, 29 June 2007
+                     GNU LESSER GENERAL PUBLIC LICENSE
+                         Version 3, 29 June 2007
   
-  Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
-  Everyone is permitted to copy and distribute verbatim copies
-  of this license document, but changing it is not allowed.
+   Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+   Everyone is permitted to copy and distribute verbatim copies
+   of this license document, but changing it is not allowed.
   
   
-  This version of the GNU Lesser General Public License incorporates
+    This version of the GNU Lesser General Public License incorporates
   the terms and conditions of version 3 of the GNU General Public
   License, supplemented by the additional permissions listed below.
   
-  0. Additional Definitions.
+    0. Additional Definitions.
   
-  As used herein, "this License" refers to version 3 of the GNU Lesser
+    As used herein, "this License" refers to version 3 of the GNU Lesser
   General Public License, and the "GNU GPL" refers to version 3 of the GNU
   General Public License.
   
-  "The Library" refers to a covered work governed by this License,
+    "The Library" refers to a covered work governed by this License,
   other than an Application or a Combined Work as defined below.
   
-  An "Application" is any work that makes use of an interface provided
+    An "Application" is any work that makes use of an interface provided
   by the Library, but which is not otherwise based on the Library.
   Defining a subclass of a class defined by the Library is deemed a mode
   of using an interface provided by the Library.
   
-  A "Combined Work" is a work produced by combining or linking an
+    A "Combined Work" is a work produced by combining or linking an
   Application with the Library.  The particular version of the Library
   with which the Combined Work was made is also called the "Linked
   Version".
   
-  The "Minimal Corresponding Source" for a Combined Work means the
+    The "Minimal Corresponding Source" for a Combined Work means the
   Corresponding Source for the Combined Work, excluding any source code
   for portions of the Combined Work that, considered in isolation, are
   based on the Application, and not on the Linked Version.
   
-  The "Corresponding Application Code" for a Combined Work means the
+    The "Corresponding Application Code" for a Combined Work means the
   object code and/or source code for the Application, including any data
   and utility programs needed for reproducing the Combined Work from the
   Application, but excluding the System Libraries of the Combined Work.
   
-  1. Exception to Section 3 of the GNU GPL.
+    1. Exception to Section 3 of the GNU GPL.
   
-  You may convey a covered work under sections 3 and 4 of this License
+    You may convey a covered work under sections 3 and 4 of this License
   without being bound by section 3 of the GNU GPL.
   
-  2. Conveying Modified Versions.
+    2. Conveying Modified Versions.
   
-  If you modify a copy of the Library, and, in your modifications, a
+    If you modify a copy of the Library, and, in your modifications, a
   facility refers to a function or data to be supplied by an Application
   that uses the facility (other than as an argument passed when the
   facility is invoked), then you may convey a copy of the modified
   version:
   
-  a) under this License, provided that you make a good faith effort to
-  ensure that, in the event an Application does not supply the
-  function or data, the facility still operates, and performs
-  whatever part of its purpose remains meaningful, or
+     a) under this License, provided that you make a good faith effort to
+     ensure that, in the event an Application does not supply the
+     function or data, the facility still operates, and performs
+     whatever part of its purpose remains meaningful, or
   
-  b) under the GNU GPL, with none of the additional permissions of
-  this License applicable to that copy.
+     b) under the GNU GPL, with none of the additional permissions of
+     this License applicable to that copy.
   
-  3. Object Code Incorporating Material from Library Header Files.
+    3. Object Code Incorporating Material from Library Header Files.
   
-  The object code form of an Application may incorporate material from
+    The object code form of an Application may incorporate material from
   a header file that is part of the Library.  You may convey such object
   code under terms of your choice, provided that, if the incorporated
   material is not limited to numerical parameters, data structure
   layouts and accessors, or small macros, inline functions and templates
   (ten or fewer lines in length), you do both of the following:
   
-  a) Give prominent notice with each copy of the object code that the
-  Library is used in it and that the Library and its use are
-  covered by this License.
+     a) Give prominent notice with each copy of the object code that the
+     Library is used in it and that the Library and its use are
+     covered by this License.
   
-  b) Accompany the object code with a copy of the GNU GPL and this license
-  document.
+     b) Accompany the object code with a copy of the GNU GPL and this license
+     document.
   
-  4. Combined Works.
+    4. Combined Works.
   
-  You may convey a Combined Work under terms of your choice that,
+    You may convey a Combined Work under terms of your choice that,
   taken together, effectively do not restrict modification of the
   portions of the Library contained in the Combined Work and reverse
   engineering for debugging such modifications, if you also do each of
   the following:
   
-  a) Give prominent notice with each copy of the Combined Work that
-  the Library is used in it and that the Library and its use are
-  covered by this License.
+     a) Give prominent notice with each copy of the Combined Work that
+     the Library is used in it and that the Library and its use are
+     covered by this License.
   
-  b) Accompany the Combined Work with a copy of the GNU GPL and this license
-  document.
+     b) Accompany the Combined Work with a copy of the GNU GPL and this license
+     document.
   
-  c) For a Combined Work that displays copyright notices during
-  execution, include the copyright notice for the Library among
-  these notices, as well as a reference directing the user to the
-  copies of the GNU GPL and this license document.
+     c) For a Combined Work that displays copyright notices during
+     execution, include the copyright notice for the Library among
+     these notices, as well as a reference directing the user to the
+     copies of the GNU GPL and this license document.
   
-  d) Do one of the following:
+     d) Do one of the following:
   
-  0) Convey the Minimal Corresponding Source under the terms of this
-  License, and the Corresponding Application Code in a form
-  suitable for, and under terms that permit, the user to
-  recombine or relink the Application with a modified version of
-  the Linked Version to produce a modified Combined Work, in the
-  manner specified by section 6 of the GNU GPL for conveying
-  Corresponding Source.
+         0) Convey the Minimal Corresponding Source under the terms of this
+         License, and the Corresponding Application Code in a form
+         suitable for, and under terms that permit, the user to
+         recombine or relink the Application with a modified version of
+         the Linked Version to produce a modified Combined Work, in the
+         manner specified by section 6 of the GNU GPL for conveying
+         Corresponding Source.
   
-  1) Use a suitable shared library mechanism for linking with the
-  Library.  A suitable mechanism is one that (a) uses at run time
-  a copy of the Library already present on the user's computer
-  system, and (b) will operate properly with a modified version
-  of the Library that is interface-compatible with the Linked
-  Version.
+         1) Use a suitable shared library mechanism for linking with the
+         Library.  A suitable mechanism is one that (a) uses at run time
+         a copy of the Library already present on the user's computer
+         system, and (b) will operate properly with a modified version
+         of the Library that is interface-compatible with the Linked
+         Version.
   
-  e) Provide Installation Information, but only if you would otherwise
-  be required to provide such information under section 6 of the
-  GNU GPL, and only to the extent that such information is
-  necessary to install and execute a modified version of the
-  Combined Work produced by recombining or relinking the
-  Application with a modified version of the Linked Version. (If
-  you use option 4d0, the Installation Information must accompany
-  the Minimal Corresponding Source and Corresponding Application
-  Code. If you use option 4d1, you must provide the Installation
-  Information in the manner specified by section 6 of the GNU GPL
-  for conveying Corresponding Source.)
+     e) Provide Installation Information, but only if you would otherwise
+     be required to provide such information under section 6 of the
+     GNU GPL, and only to the extent that such information is
+     necessary to install and execute a modified version of the
+     Combined Work produced by recombining or relinking the
+     Application with a modified version of the Linked Version. (If
+     you use option 4d0, the Installation Information must accompany
+     the Minimal Corresponding Source and Corresponding Application
+     Code. If you use option 4d1, you must provide the Installation
+     Information in the manner specified by section 6 of the GNU GPL
+     for conveying Corresponding Source.)
   
-  5. Combined Libraries.
+    5. Combined Libraries.
   
-  You may place library facilities that are a work based on the
+    You may place library facilities that are a work based on the
   Library side by side in a single library together with other library
   facilities that are not Applications and are not covered by this
   License, and convey such a combined library under terms of your
   choice, if you do both of the following:
   
-  a) Accompany the combined library with a copy of the same work based
-  on the Library, uncombined with any other library facilities,
-  conveyed under the terms of this License.
+     a) Accompany the combined library with a copy of the same work based
+     on the Library, uncombined with any other library facilities,
+     conveyed under the terms of this License.
   
-  b) Give prominent notice with the combined library that part of it
-  is a work based on the Library, and explaining where to find the
-  accompanying uncombined form of the same work.
+     b) Give prominent notice with the combined library that part of it
+     is a work based on the Library, and explaining where to find the
+     accompanying uncombined form of the same work.
   
-  6. Revised Versions of the GNU Lesser General Public License.
+    6. Revised Versions of the GNU Lesser General Public License.
   
-  The Free Software Foundation may publish revised and/or new versions
+    The Free Software Foundation may publish revised and/or new versions
   of the GNU Lesser General Public License from time to time. Such new
   versions will be similar in spirit to the present version, but may
   differ in detail to address new problems or concerns.
   
-  Each version is given a distinguishing version number. If the
+    Each version is given a distinguishing version number. If the
   Library as you received it specifies that a certain numbered version
   of the GNU Lesser General Public License "or any later version"
   applies to it, you have the option of following the terms and
@@ -2719,7 +2725,7 @@
   General Public License, you may choose any version of the GNU Lesser
   General Public License ever published by the Free Software Foundation.
   
-  If the Library as you received it specifies that a proxy can decide
+    If the Library as you received it specifies that a proxy can decide
   whether future versions of the GNU Lesser General Public License shall
   apply, that proxy's public statement of acceptance of any version is
   permanent authorization for you to choose that version for the


### PR DESCRIPTION
Whitespace in the previous templates did not match the source licenses